### PR TITLE
feat: Add generic callStatic return type to TransactionMethods

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -34,6 +34,7 @@ import type {
   TipInputItem,
   TransactionMethods,
   Fulfillment,
+  ContractMethodReturnType,
 } from "./types";
 import { getApprovalActions } from "./utils/approval";
 import {
@@ -372,7 +373,7 @@ export class Seaport {
   public cancelOrders(
     orders: OrderComponents[],
     accountAddress?: string
-  ): TransactionMethods {
+  ): TransactionMethods<ContractMethodReturnType<SeaportContract, "cancel">> {
     const signer = this.provider.getSigner(accountAddress);
 
     return getTransactionMethods(this.contract.connect(signer), "cancel", [
@@ -385,7 +386,11 @@ export class Seaport {
    * @param offerer the account to bulk cancel orders on
    * @returns the set of transaction methods that can be used
    */
-  public bulkCancelOrders(offerer?: string): TransactionMethods {
+  public bulkCancelOrders(
+    offerer?: string
+  ): TransactionMethods<
+    ContractMethodReturnType<SeaportContract, "incrementNonce">
+  > {
     const signer = this.provider.getSigner(offerer);
 
     return getTransactionMethods(
@@ -405,7 +410,7 @@ export class Seaport {
   public validate(
     orders: Order[],
     accountAddress?: string
-  ): TransactionMethods {
+  ): TransactionMethods<ContractMethodReturnType<SeaportContract, "validate">> {
     const signer = this.provider.getSigner(accountAddress);
 
     return getTransactionMethods(this.contract.connect(signer), "validate", [
@@ -581,7 +586,16 @@ export class Seaport {
     extraData?: string;
     accountAddress?: string;
     conduitKey?: string;
-  }): Promise<OrderUseCase<ExchangeAction>> {
+  }): Promise<
+    OrderUseCase<
+      ExchangeAction<
+        ContractMethodReturnType<
+          SeaportContract,
+          "fulfillBasicOrder" | "fulfillOrder" | "fulfillAdvancedOrder"
+        >
+      >
+    >
+  > {
     const { parameters: orderParameters } = order;
     const { offerer, offer, consideration } = orderParameters;
 
@@ -819,7 +833,9 @@ export class Seaport {
     orders: OrderWithNonce[];
     fulfillments: Fulfillment[];
     overrides?: PayableOverrides;
-  }): TransactionMethods {
+  }): TransactionMethods<
+    ContractMethodReturnType<SeaportContract, "matchOrders">
+  > {
     return getTransactionMethods(this.contract, "matchOrders", [
       orders,
       fulfillments,

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -5,13 +5,14 @@ import {
   ethers,
   providers,
 } from "ethers";
-import { BasicOrderRouteType, ItemType, NO_CONDUIT } from "../constants";
 import type {
+  Seaport as SeaportContract,
   BasicOrderParametersStruct,
   Seaport,
   FulfillmentComponentStruct,
   OrderStruct,
 } from "../typechain/Seaport";
+import { BasicOrderRouteType, ItemType, NO_CONDUIT } from "../constants";
 import type {
   AdvancedOrder,
   ConsiderationItem,
@@ -21,6 +22,7 @@ import type {
   OrderParameters,
   OrderStatus,
   OrderUseCase,
+  ContractMethodReturnType,
 } from "../types";
 import { getApprovalActions } from "./approval";
 import {
@@ -198,7 +200,13 @@ export async function fulfillBasicOrder({
   signer: providers.JsonRpcSigner;
   tips?: ConsiderationItem[];
   conduitKey: string;
-}): Promise<OrderUseCase<ExchangeAction>> {
+}): Promise<
+  OrderUseCase<
+    ExchangeAction<
+      ContractMethodReturnType<SeaportContract, "fulfillBasicOrder">
+    >
+  >
+> {
   const { offer, consideration } = order.parameters;
   const considerationIncludingTips = [...consideration, ...tips];
 
@@ -286,7 +294,7 @@ export async function fulfillBasicOrder({
       "fulfillBasicOrder",
       [basicOrderParameters, payableOverrides]
     ),
-  } as ExchangeAction;
+  } as const;
 
   const actions = [...approvalActions, exchangeAction] as const;
 
@@ -331,7 +339,16 @@ export async function fulfillStandardOrder({
   conduitKey: string;
   timeBasedItemParams: TimeBasedItemParams;
   signer: providers.JsonRpcSigner;
-}): Promise<OrderUseCase<ExchangeAction>> {
+}): Promise<
+  OrderUseCase<
+    ExchangeAction<
+      ContractMethodReturnType<
+        SeaportContract,
+        "fulfillAdvancedOrder" | "fulfillOrder"
+      >
+    >
+  >
+> {
   // If we are supplying units to fill, we adjust the order by the minimum of the amount to fill and
   // the remaining order left to be fulfilled
   const orderWithAdjustedFills = unitsToFill
@@ -508,7 +525,16 @@ export async function fulfillAvailableOrders({
   ascendingAmountTimestampBuffer: number;
   conduitKey: string;
   signer: providers.JsonRpcSigner;
-}): Promise<OrderUseCase<ExchangeAction>> {
+}): Promise<
+  OrderUseCase<
+    ExchangeAction<
+      ContractMethodReturnType<
+        SeaportContract,
+        "fulfillAvailableAdvancedOrders"
+      >
+    >
+  >
+> {
   const sanitizedOrdersMetadata = ordersMetadata.map((orderMetadata) => ({
     ...orderMetadata,
     order: validateAndSanitizeFromOrderStatus(

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -4,6 +4,7 @@ import {
   ExchangeAction,
   OrderUseCase,
   TransactionMethods,
+  ContractMethodReturnType,
 } from "../types";
 
 export const executeAllActions = async <
@@ -55,7 +56,7 @@ export const getTransactionMethods = <
   contract: T,
   method: U,
   args: Parameters<T["functions"][U]>
-): TransactionMethods => {
+): TransactionMethods<ContractMethodReturnType<T, U>> => {
   const lastArg = args[args.length - 1];
 
   let initialOverrides: Overrides;


### PR DESCRIPTION
Let `TransactionMethods` take a single generic type for the return value of `callStatic`.

Also adds helper `ContractMethodReturnType` to get the method return type from Contract type. Made this a separate helper so that `TransactionMethods` can optionally be used without the contract type or method name.