### PR TITLE
feat: expose MerkleTree helper and require proof instead of validIden…

### DIFF
--- a/src/__tests__/criteria-based.spec.ts
+++ b/src/__tests__/criteria-based.spec.ts
@@ -8,6 +8,7 @@ import sinon from "sinon";
 import { ItemType, MAX_INT } from "../constants";
 import { CreateOrderInput, CurrencyItem } from "../types";
 import * as fulfill from "../utils/fulfill";
+import { MerkleTree } from "../utils/merkletree";
 import {
   getBalancesForFulfillOrder,
   verifyBalancesAfterFulfill,
@@ -86,7 +87,7 @@ describeWithFixture(
 
             const { actions } = await seaport.fulfillOrder({
               order,
-              offerCriteria: [{ identifier: nftId, validIdentifiers: [] }],
+              offerCriteria: [{ identifier: nftId, proof: [] }],
               accountAddress: fulfiller.address,
             });
 
@@ -156,7 +157,7 @@ describeWithFixture(
 
             const { actions } = await seaport.fulfillOrder({
               order,
-              offerCriteria: [{ identifier: nftId, validIdentifiers: [] }],
+              offerCriteria: [{ identifier: nftId, proof: [] }],
               accountAddress: fulfiller.address,
             });
 
@@ -260,9 +261,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
 
-              considerationCriteria: [
-                { identifier: nftId, validIdentifiers: [] },
-              ],
+              considerationCriteria: [{ identifier: nftId, proof: [] }],
               accountAddress: fulfiller.address,
             });
 
@@ -384,7 +383,10 @@ describeWithFixture(
             const { actions: revertedActions } = await seaport.fulfillOrder({
               order,
               offerCriteria: [
-                { identifier: nftId2, validIdentifiers: [nftId2] },
+                {
+                  identifier: nftId2,
+                  proof: new MerkleTree([nftId2]).getProof(nftId2),
+                },
               ],
               accountAddress: fulfiller.address,
             });
@@ -409,7 +411,7 @@ describeWithFixture(
               offerCriteria: [
                 {
                   identifier: nftId3,
-                  validIdentifiers: [nftId, nftId3],
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId3),
                 },
               ],
               accountAddress: fulfiller.address,
@@ -479,7 +481,10 @@ describeWithFixture(
               order,
 
               offerCriteria: [
-                { identifier: nftId2, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId2,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId2),
+                },
               ],
               accountAddress: fulfiller.address,
             });
@@ -521,7 +526,10 @@ describeWithFixture(
               order,
 
               offerCriteria: [
-                { identifier: nftId3, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId3,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId3),
+                },
               ],
 
               accountAddress: fulfiller.address,
@@ -607,7 +615,10 @@ describeWithFixture(
             const { actions: revertedActions } = await seaport.fulfillOrder({
               order,
               considerationCriteria: [
-                { identifier: nftId2, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId2,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId2),
+                },
               ],
               accountAddress: fulfiller.address,
             });
@@ -668,7 +679,10 @@ describeWithFixture(
               order,
 
               considerationCriteria: [
-                { identifier: nftId3, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId3,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId3),
+                },
               ],
 
               accountAddress: fulfiller.address,
@@ -738,7 +752,7 @@ describeWithFixture(
 
             const { actions } = await seaport.fulfillOrder({
               order,
-              offerCriteria: [{ identifier: nftId, validIdentifiers: [] }],
+              offerCriteria: [{ identifier: nftId, proof: [] }],
               accountAddress: fulfiller.address,
             });
 
@@ -790,7 +804,7 @@ describeWithFixture(
 
             const { actions } = await seaport.fulfillOrder({
               order,
-              offerCriteria: [{ identifier: nftId, validIdentifiers: [] }],
+              offerCriteria: [{ identifier: nftId, proof: [] }],
               accountAddress: fulfiller.address,
             });
 
@@ -879,9 +893,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
 
-              considerationCriteria: [
-                { identifier: nftId, validIdentifiers: [] },
-              ],
+              considerationCriteria: [{ identifier: nftId, proof: [] }],
               accountAddress: fulfiller.address,
             });
 
@@ -989,7 +1001,10 @@ describeWithFixture(
             const { actions: revertedActions } = await seaport.fulfillOrder({
               order,
               offerCriteria: [
-                { identifier: nftId2, validIdentifiers: [nftId2] },
+                {
+                  identifier: nftId2,
+                  proof: new MerkleTree([nftId2]).getProof(nftId2),
+                },
               ],
               accountAddress: fulfiller.address,
             });
@@ -1014,7 +1029,7 @@ describeWithFixture(
               offerCriteria: [
                 {
                   identifier: nftId3,
-                  validIdentifiers: [nftId, nftId3],
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId3),
                 },
               ],
               accountAddress: fulfiller.address,
@@ -1070,7 +1085,10 @@ describeWithFixture(
               order,
 
               offerCriteria: [
-                { identifier: nftId2, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId2,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId2),
+                },
               ],
               accountAddress: fulfiller.address,
             });
@@ -1112,7 +1130,10 @@ describeWithFixture(
               order,
 
               offerCriteria: [
-                { identifier: nftId3, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId3,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId3),
+                },
               ],
 
               accountAddress: fulfiller.address,
@@ -1185,7 +1206,10 @@ describeWithFixture(
             const { actions: revertedActions } = await seaport.fulfillOrder({
               order,
               considerationCriteria: [
-                { identifier: nftId2, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId2,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId2),
+                },
               ],
               accountAddress: fulfiller.address,
             });
@@ -1246,7 +1270,10 @@ describeWithFixture(
               order,
 
               considerationCriteria: [
-                { identifier: nftId3, validIdentifiers: [nftId, nftId3] },
+                {
+                  identifier: nftId3,
+                  proof: new MerkleTree([nftId, nftId3]).getProof(nftId3),
+                },
               ],
 
               accountAddress: fulfiller.address,
@@ -1309,10 +1336,8 @@ describeWithFixture(
 
           const { actions } = await seaport.fulfillOrder({
             order,
-            offerCriteria: [{ identifier: nftId, validIdentifiers: [] }],
-            considerationCriteria: [
-              { identifier: nftId2, validIdentifiers: [] },
-            ],
+            offerCriteria: [{ identifier: nftId, proof: [] }],
+            considerationCriteria: [{ identifier: nftId2, proof: [] }],
             accountAddress: fulfiller.address,
           });
 
@@ -1398,9 +1423,17 @@ describeWithFixture(
 
           const { actions: revertedActions } = await seaport.fulfillOrder({
             order,
-            offerCriteria: [{ identifier: nftId2, validIdentifiers: [nftId2] }],
+            offerCriteria: [
+              {
+                identifier: nftId2,
+                proof: new MerkleTree([nftId2]).getProof(nftId2),
+              },
+            ],
             considerationCriteria: [
-              { identifier: nftId2, validIdentifiers: [nftId2, nftId3] },
+              {
+                identifier: nftId2,
+                proof: new MerkleTree([nftId2, nftId3]).getProof(nftId2),
+              },
             ],
             accountAddress: fulfiller.address,
           });
@@ -1435,10 +1468,16 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             offerCriteria: [
-              { identifier: nftId, validIdentifiers: [nftId, nftId3] },
+              {
+                identifier: nftId,
+                proof: new MerkleTree([nftId, nftId3]).getProof(nftId),
+              },
             ],
             considerationCriteria: [
-              { identifier: nftId2, validIdentifiers: [nftId2, nftId3] },
+              {
+                identifier: nftId2,
+                proof: new MerkleTree([nftId2, nftId3]).getProof(nftId2),
+              },
             ],
             accountAddress: fulfiller.address,
           });

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -88,7 +88,7 @@ export class Seaport {
       ascendingAmountFulfillmentBuffer = 300,
       balanceAndApprovalChecksOnOrderCreation = true,
       conduitKeyToConduit,
-    }: SeaportConfig
+    }: SeaportConfig = {}
   ) {
     this.provider = provider;
     this.multicallProvider = new multicallProviders.MulticallProvider(provider);

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,7 +146,7 @@ export type CreateOrderInput = {
 
 export type InputCriteria = {
   identifier: string;
-  validIdentifiers: string[];
+  proof: string[];
 };
 
 export type OrderStatus = {

--- a/src/utils/criteria.ts
+++ b/src/utils/criteria.ts
@@ -1,6 +1,3 @@
-import { BigNumber } from "ethers";
-import { keccak256 } from "ethers/lib/utils";
-import MerkleTree from "merkletreejs";
 import { Side } from "../constants";
 import { InputCriteria, Item, Order } from "../types";
 import { isCriteriaItem } from "./item";
@@ -50,23 +47,14 @@ export const generateCriteriaResolvers = ({
   ) =>
     criteriaItems.map(({ orderIndex, item, index, side }, i) => {
       const merkleRoot = item.identifierOrCriteria || "0";
-      const inputCriteria = criterias[orderIndex][i];
-      const leaves = (inputCriteria.validIdentifiers ?? []).map(hashIdentifier);
-
-      const tree = new MerkleTree(leaves, keccak256, {
-        sort: true,
-      });
-
-      const criteriaProof = tree.getHexProof(
-        hashIdentifier(inputCriteria.identifier)
-      );
+      const inputCriteria: InputCriteria = criterias[orderIndex][i];
 
       return {
         orderIndex,
         index,
         side,
         identifier: inputCriteria.identifier,
-        criteriaProof: merkleRoot === "0" ? [] : criteriaProof,
+        criteriaProof: merkleRoot === "0" ? [] : inputCriteria.proof,
       };
     });
 
@@ -94,11 +82,3 @@ export const getItemToCriteriaMap = (
     return map;
   }, new Map<Item, InputCriteria>());
 };
-
-export const hashIdentifier = (identifier: string) =>
-  keccak256(
-    Buffer.from(
-      BigNumber.from(identifier).toHexString().slice(2).padStart(64, "0"),
-      "hex"
-    )
-  );

--- a/src/utils/merkletree.ts
+++ b/src/utils/merkletree.ts
@@ -1,0 +1,33 @@
+import { BigNumber } from "ethers";
+import { keccak256 } from "ethers/lib/utils";
+import MerkleTreeJS from "merkletreejs";
+
+const hashIdentifier = (identifier: string) =>
+  keccak256(
+    Buffer.from(
+      BigNumber.from(identifier).toHexString().slice(2).padStart(64, "0"),
+      "hex"
+    )
+  );
+
+/**
+ * Simple wrapper over the MerkleTree in merkletreejs.
+ * Handles hashing identifiers to be compatible with Seaport.
+ */
+export class MerkleTree {
+  tree: MerkleTreeJS;
+
+  constructor(identifiers: string[]) {
+    this.tree = new MerkleTreeJS(identifiers.map(hashIdentifier), keccak256, {
+      sort: true,
+    });
+  }
+
+  getProof(identifier: string): string[] {
+    return this.tree.getHexProof(hashIdentifier(identifier));
+  }
+
+  getRoot() {
+    return this.tree.getRoot().toString("hex") ? this.tree.getHexRoot() : "0";
+  }
+}


### PR DESCRIPTION
…tifiers

It makes more sense to supply the proof as opposed to the valid identifiers. Also expose a merkle tree helper class for consumers to use if they want to generate their own Seaport compatible proofs.