### PR TITLE
fix: set signer in Seaport constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a new marketplace protocol for safely and efficiently buying and selling NFTs. This is a JavaScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -100,6 +100,7 @@ export class Seaport {
       providerOrSigner instanceof providers.Provider
         ? providerOrSigner
         : providerOrSigner.provider;
+    this.signer = (providerOrSigner as Signer)._isSigner ? providerOrSigner as Signer : undefined;
 
     if (!provider) {
       throw new Error(

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -100,7 +100,9 @@ export class Seaport {
       providerOrSigner instanceof providers.Provider
         ? providerOrSigner
         : providerOrSigner.provider;
-    this.signer = (providerOrSigner as Signer)._isSigner ? providerOrSigner as Signer : undefined;
+    this.signer = (providerOrSigner as Signer)._isSigner
+      ? (providerOrSigner as Signer)
+      : undefined;
 
     if (!provider) {
       throw new Error(


### PR DESCRIPTION
Fix bug where signer was not being set in constructor.

## Motivation
The Seaport constructor now accepts a signer, but doesn't actually set the `signer` class variable in the constructor, causing `_getSigner` to throw an error.

## Solution
Solution is to set `signer` in the constructor.
