### PR TITLE
fix: it should wait for tx to be included when sending approve transa…

### DIFF
--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -15,7 +15,8 @@ export const executeAllActions = async <
   for (let i = 0; i < actions.length - 1; i++) {
     const action = actions[i];
     if (action.type === "approval") {
-      await action.transactionMethods.transact();
+      const tx = await action.transactionMethods.transact();
+      await tx.wait();
     }
   }
 


### PR DESCRIPTION
Fix await tx be included when sending approve transaction.

## Motivation
Hello, when i  use a new address to createSellOrder/createBuyOrder,  it will call createOrder and make an actions array with [approve, create].
I found the create action will wait for the approve action be send to the node, but it not wait for the approve tx be included and on chain.
It leads to a series of API problems, just like: 
`API Error 400: You must approve assets #0 for trading before creating an order`
`API Error 400: You must approve warpped ether for trading before creating an order`
...


## Solution

Just add `tx.wait()` to the approve action when call the `executeAllActions` function.