### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const seaport = new Seaport(provider);
 import { Seaport } from "@opensea/seaport-js";
 import { ethers } from "ethers";
 
-const provider = new ethers.provider.JsonRpcProvider(
+const provider = new ethers.providers.JsonRpcProvider(
   "https://<network>.alchemyapi.io/v2/YOUR-API-KEY"
 );
 
@@ -67,7 +67,7 @@ import { Seaport } from "@opensea/seaport-js";
 import { ethers } from "ethers";
 
 // Provider must be provided to the signer when supplying a custom signer
-const provider = new ethers.provider.JsonRpcProvider(
+const provider = new ethers.providers.JsonRpcProvider(
   "https://<network>.alchemyapi.io/v2/YOUR-API-KEY"
 );
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ const { executeAllActions } = await seaport.createOrder(
     ],
     consideration: [
       {
-        amount: parseEther("10").toString(),
+        amount: ethers.utils.parseEther("10").toString(),
         recipient: offerer,
       },
     ],


### PR DESCRIPTION
```diff
- const provider = new ethers.provider.JsonRpcProvider(
+ const provider = new ethers.providers.JsonRpcProvider(
  "https://<network>.alchemyapi.io/v2/YOUR-API-KEY"
);
```

```diff
- amount: parseEther("10").toString(),
+ amount: ethers.utils.parseEther("10").toString(),
```

## Motivation
* To fix bugs in the README.md:
Bug 1:
```
Property 'provider' does not exist on type 'typeof import("./node_modules/ethers/lib/ethers")'. Did you mean 'providers'?
```
Bug 2:
```
Cannot find name 'parseEther'.
```


## Solution
Fix 1:
Simply change from `provider` to `providers`.

Fix 2
Specify property path of `parseEther` 
