### PR TITLE
updates to support matchOrder creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@0xsequence/multicall": "^0.39.0",
         "ethers": "^5.6.7",
-        "merkletreejs": "^0.2.31"
+        "merkletreejs": "^0.2.31",
+        "yarn": "^1.22.19"
       },
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.5",
@@ -25007,6 +25008,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/yarn": {
+      "version": "1.22.19",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+      "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "yarn": "bin/yarn.js",
+        "yarnpkg": "bin/yarn.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
@@ -44318,6 +44332,11 @@
           "dev": true
         }
       }
+    },
+    "yarn": {
+      "version": "1.22.19",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+      "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ=="
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint:check": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
     "lint": "concurrently \"npm run check-types\" \"npm run eslint:check\" \"npm run prettier:check\" \"npm run prettier:check:package.json\"",
     "prepare": "husky install && npm run build",
+    "publish": "yalc push",
     "test": "hardhat test",
     "prettier:check": "prettier --check .",
     "prettier:check:package.json": "prettier-package-json --list-different",
@@ -37,7 +38,8 @@
   "dependencies": {
     "@0xsequence/multicall": "^0.39.0",
     "ethers": "^5.6.7",
-    "merkletreejs": "^0.2.31"
+    "merkletreejs": "^0.2.31",
+    "yarn": "^1.22.19"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/src/__tests__/match-orders.spec.ts
+++ b/src/__tests__/match-orders.spec.ts
@@ -22,6 +22,7 @@ describeWithFixture("As a user I want to match an order", (fixture) => {
   let offerer: SignerWithAddress;
   let zone: SignerWithAddress;
   let privateListingRecipient: SignerWithAddress;
+
   let privateListingCreateOrderInput: CreateOrderInput;
   let multicallProvider: providers.MulticallProvider;
   const nftId = "1";
@@ -29,7 +30,13 @@ describeWithFixture("As a user I want to match an order", (fixture) => {
   const erc1155ListingQuantity = "1";
 
   beforeEach(async () => {
-    [offerer, zone, privateListingRecipient] = await ethers.getSigners();
+    /**
+     * The first signer is the Seaport.js client signer, so we ignore it
+     * as the client signer is decoupled from the offerer and fulfiller
+     * in matchOrders calls
+     */
+
+    [, offerer, zone, privateListingRecipient] = await ethers.getSigners();
 
     multicallProvider = new providers.MulticallProvider(ethers.provider);
   });
@@ -72,7 +79,8 @@ describeWithFixture("As a user I want to match an order", (fixture) => {
           const { seaport } = fixture;
 
           const { executeAllActions } = await seaport.createOrder(
-            privateListingCreateOrderInput
+            privateListingCreateOrderInput,
+            offerer.address
           );
 
           const order = await executeAllActions();
@@ -141,7 +149,8 @@ describeWithFixture("As a user I want to match an order", (fixture) => {
           const { seaport, testErc20 } = fixture;
 
           const { executeAllActions } = await seaport.createOrder(
-            privateListingCreateOrderInput
+            privateListingCreateOrderInput,
+            offerer.address
           );
 
           const order = await executeAllActions();
@@ -233,7 +242,8 @@ describeWithFixture("As a user I want to match an order", (fixture) => {
           const { seaport } = fixture;
 
           const { executeAllActions } = await seaport.createOrder(
-            privateListingCreateOrderInput
+            privateListingCreateOrderInput,
+            offerer.address
           );
 
           const order = await executeAllActions();
@@ -302,7 +312,8 @@ describeWithFixture("As a user I want to match an order", (fixture) => {
           const { seaport, testErc20 } = fixture;
 
           const { executeAllActions } = await seaport.createOrder(
-            privateListingCreateOrderInput
+            privateListingCreateOrderInput,
+            offerer.address
           );
 
           const order = await executeAllActions();

--- a/src/types.ts
+++ b/src/types.ts
@@ -242,6 +242,34 @@ export type OrderUseCase<T extends CreateOrderAction | ExchangeAction> = {
   >;
 };
 
+export type CreateMatchOrderAction = Omit<CreateOrderAction, "createOrder">;
+export type ExchangeMatchOrderAction<T = unknown> = Omit<
+  ExchangeAction<T>,
+  "transactionMethods"
+>;
+
+export type MatchApprovalAction = Omit<ApprovalAction, "transactionMethods">;
+
+export type MatchOrderExchangeActions<T> = readonly [
+  ...MatchApprovalAction[],
+  ExchangeMatchOrderAction<T>
+];
+
+export type CreateMatchOrderActions = readonly [
+  ...MatchApprovalAction[],
+  CreateMatchOrderAction
+];
+
+export type MatchOrderUseCase<
+  T extends CreateMatchOrderAction | ExchangeMatchOrderAction
+> = {
+  actions: T extends CreateMatchOrderAction
+    ? CreateMatchOrderActions
+    : MatchOrderExchangeActions<
+        T extends ExchangeMatchOrderAction<infer U> ? U : never
+      >;
+};
+
 export type FulfillmentComponent = {
   orderIndex: number;
   itemIndex: number;


### PR DESCRIPTION
1. Fix bug in the way they do signer overrides
2. Add functions to get signatures and allowance actions required for order generation without offerer signer present
3. fix buggy tests