### PR TITLE
Add domain hash to random salt

### DIFF
--- a/src/__tests__/create-order.spec.ts
+++ b/src/__tests__/create-order.spec.ts
@@ -4,7 +4,10 @@ import { ethers } from "hardhat";
 import { Seaport } from "../seaport";
 import { ItemType, MAX_INT, NO_CONDUIT, OrderType } from "../constants";
 import { ApprovalAction, CreateOrderAction } from "../types";
-import { generateRandomSalt } from "../utils/order";
+import {
+  generateRandomSalt,
+  generateRandomSaltWithDomain,
+} from "../utils/order";
 import { describeWithFixture } from "./utils/setup";
 
 describeWithFixture("As a user I want to create an order", (fixture) => {
@@ -737,5 +740,50 @@ describeWithFixture("As a user I want to create an order", (fixture) => {
     const localOrderHash = seaport.getOrderHash(order.parameters);
 
     expect(contractOrderHash).eq(localOrderHash);
+  });
+
+  it("should create an order with a salt including a hash of the supplied domain", async () => {
+    const { seaportContract, seaport, testErc721 } = fixture;
+
+    const [offerer, zone] = await ethers.getSigners();
+    const nftId = "1";
+    await testErc721.mint(offerer.address, nftId);
+    const startTime = "0";
+    const endTime = MAX_INT.toString();
+    const domain = "opensea.io";
+    const openseaMagicValue = "0x360c6ebe";
+    const salt = generateRandomSaltWithDomain(domain);
+
+    const { executeAllActions } = await seaport.createOrder({
+      startTime,
+      endTime,
+      salt,
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: testErc721.address,
+          identifier: nftId,
+        },
+      ],
+      consideration: [
+        {
+          amount: ethers.utils.parseEther("10").toString(),
+          recipient: offerer.address,
+        },
+      ],
+      // 2.5% fee
+      fees: [{ recipient: zone.address, basisPoints: 250 }],
+    });
+
+    const order = await executeAllActions();
+
+    const contractOrderHash = await seaportContract.getOrderHash(
+      order.parameters
+    );
+
+    const localOrderHash = seaport.getOrderHash(order.parameters);
+
+    expect(contractOrderHash).eq(localOrderHash);
+    expect(salt.slice(0, 10)).eq(openseaMagicValue);
   });
 });

--- a/src/__tests__/create-order.spec.ts
+++ b/src/__tests__/create-order.spec.ts
@@ -4,10 +4,7 @@ import { ethers } from "hardhat";
 import { Seaport } from "../seaport";
 import { ItemType, MAX_INT, NO_CONDUIT, OrderType } from "../constants";
 import { ApprovalAction, CreateOrderAction } from "../types";
-import {
-  generateRandomSalt,
-  generateRandomSaltWithDomain,
-} from "../utils/order";
+import { generateRandomSalt } from "../utils/order";
 import { describeWithFixture } from "./utils/setup";
 
 describeWithFixture("As a user I want to create an order", (fixture) => {

--- a/src/__tests__/create-order.spec.ts
+++ b/src/__tests__/create-order.spec.ts
@@ -786,4 +786,47 @@ describeWithFixture("As a user I want to create an order", (fixture) => {
     expect(contractOrderHash).eq(localOrderHash);
     expect(salt.slice(0, 10)).eq(openseaMagicValue);
   });
+
+  it("should create an order with a salt with the first four bytes being empty if no domain is given", async () => {
+    const { seaportContract, seaport, testErc721 } = fixture;
+
+    const [offerer, zone] = await ethers.getSigners();
+    const nftId = "1";
+    await testErc721.mint(offerer.address, nftId);
+    const startTime = "0";
+    const endTime = MAX_INT.toString();
+    const salt = generateRandomSalt();
+
+    const { executeAllActions } = await seaport.createOrder({
+      startTime,
+      endTime,
+      salt,
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: testErc721.address,
+          identifier: nftId,
+        },
+      ],
+      consideration: [
+        {
+          amount: ethers.utils.parseEther("10").toString(),
+          recipient: offerer.address,
+        },
+      ],
+      // 2.5% fee
+      fees: [{ recipient: zone.address, basisPoints: 250 }],
+    });
+
+    const order = await executeAllActions();
+
+    const contractOrderHash = await seaportContract.getOrderHash(
+      order.parameters
+    );
+
+    const localOrderHash = seaport.getOrderHash(order.parameters);
+
+    expect(contractOrderHash).eq(localOrderHash);
+    expect(salt.slice(0, 10)).eq("0x00000000");
+  });
 });

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -189,7 +189,8 @@ export class Seaport {
    * @param input.restrictedByZone Whether the order should be restricted by zone
    * @param input.fees Convenience array to apply fees onto the order. The fees will be deducted from the
    *                   existing consideration items and then tacked on as new consideration items
-   * @param input.salt Random salt
+   * @param input.domain An optional domain to be hashed and included in the first four bytes of the random salt.
+   * @param input.salt Random salt including the hashed domain if one is provided
    * @param input.offerer The order's creator address. Defaults to the first address on the provider.
    * @param accountAddress Optional address for which to create the order with
    * @returns a use case containing the list of actions needed to be performed in order to create the order

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -190,7 +190,7 @@ export class Seaport {
    * @param input.fees Convenience array to apply fees onto the order. The fees will be deducted from the
    *                   existing consideration items and then tacked on as new consideration items
    * @param input.domain An optional domain to be hashed and included in the first four bytes of the random salt.
-   * @param input.salt Random salt including the hashed domain if one is provided
+   * @param input.saltOverride Arbitrary salt. If not passed in, a random salt will be generated with the first four bytes being the domain hash or empty.
    * @param input.offerer The order's creator address. Defaults to the first address on the provider.
    * @param accountAddress Optional address for which to create the order with
    * @returns a use case containing the list of actions needed to be performed in order to create the order
@@ -208,9 +208,7 @@ export class Seaport {
       restrictedByZone,
       fees,
       domain,
-      salt = domain
-        ? generateRandomSaltWithDomain(domain)
-        : generateRandomSalt(),
+      salt,
     }: CreateOrderInput,
     accountAddress?: string
   ): Promise<OrderUseCase<CreateOrderAction>> {
@@ -273,6 +271,12 @@ export class Seaport {
         : []),
     ];
 
+    const saltParam = salt
+      ? salt
+      : domain
+      ? generateRandomSaltWithDomain(domain)
+      : generateRandomSalt();
+
     const orderParameters: OrderParameters = {
       offerer,
       zone,
@@ -284,7 +288,7 @@ export class Seaport {
       offer: offerItems,
       consideration: considerationItemsWithFees,
       totalOriginalConsiderationItems: considerationItemsWithFees.length,
-      salt,
+      salt: saltParam,
       conduitKey,
     };
 

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -271,11 +271,9 @@ export class Seaport {
         : []),
     ];
 
-    const saltFollowingConditional = salt
-      ? salt
-      : domain
-      ? generateRandomSaltWithDomain(domain)
-      : generateRandomSalt();
+    const saltFollowingConditional =
+      salt ||
+      (domain ? generateRandomSaltWithDomain(domain) : generateRandomSalt());
 
     const orderParameters: OrderParameters = {
       offerer,

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -190,7 +190,7 @@ export class Seaport {
    * @param input.fees Convenience array to apply fees onto the order. The fees will be deducted from the
    *                   existing consideration items and then tacked on as new consideration items
    * @param input.domain An optional domain to be hashed and included in the first four bytes of the random salt.
-   * @param input.saltOverride Arbitrary salt. If not passed in, a random salt will be generated with the first four bytes being the domain hash or empty.
+   * @param input.salt Arbitrary salt. If not passed in, a random salt will be generated with the first four bytes being the domain hash or empty.
    * @param input.offerer The order's creator address. Defaults to the first address on the provider.
    * @param accountAddress Optional address for which to create the order with
    * @returns a use case containing the list of actions needed to be performed in order to create the order
@@ -271,7 +271,7 @@ export class Seaport {
         : []),
     ];
 
-    const saltParam = salt
+    const saltFollowingConditional = salt
       ? salt
       : domain
       ? generateRandomSaltWithDomain(domain)
@@ -288,7 +288,7 @@ export class Seaport {
       offer: offerItems,
       consideration: considerationItemsWithFees,
       totalOriginalConsiderationItems: considerationItemsWithFees.length,
-      salt: saltParam,
+      salt: saltFollowingConditional,
       conduitKey,
     };
 

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -207,7 +207,9 @@ export class Seaport {
       restrictedByZone,
       fees,
       domain,
-      salt = domain ? generateRandomSaltWithDomain(domain) : generateRandomSalt(),
+      salt = domain
+        ? generateRandomSaltWithDomain(domain)
+        : generateRandomSalt(),
     }: CreateOrderInput,
     accountAddress?: string
   ): Promise<OrderUseCase<CreateOrderAction>> {

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -57,6 +57,7 @@ import {
   deductFees,
   feeToConsiderationItem,
   generateRandomSalt,
+  generateRandomSaltWithDomain,
   mapInputItemToOfferItem,
   totalItemsAmount,
 } from "./utils/order";
@@ -205,7 +206,8 @@ export class Seaport {
       allowPartialFills,
       restrictedByZone,
       fees,
-      salt = generateRandomSalt(),
+      domain,
+      salt = domain ? generateRandomSaltWithDomain(domain) : generateRandomSalt(),
     }: CreateOrderInput,
     accountAddress?: string
   ): Promise<OrderUseCase<CreateOrderAction>> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,7 @@ export type CreateOrderInput = {
   allowPartialFills?: boolean;
   restrictedByZone?: boolean;
   useProxy?: boolean;
+  domain?: string;
   salt?: string;
 };
 

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -273,11 +273,17 @@ export const mapOrderAmountsFromUnitsToFill = (
 };
 
 export const generateRandomSalt = () => {
-  return `0x${Buffer.from(ethers.utils.randomBytes(12)).toString("hex").padStart(8, "0")}`;
+  return `0x${Buffer.from(randomBytes(8)).toString("hex").padStart(24, "0")}`;
 };
 
 export const generateRandomSaltWithDomain = (domain: string) => {
-  return `0x${Buffer.from(concat([keccak256(toUtf8Bytes(domain)).slice(2,10), randomBytes(8)])).toString("hex")}`;
-}
+  return `0x${Buffer.from(
+    concat([
+      keccak256(toUtf8Bytes(domain)).slice(0, 10),
+      Uint8Array.from(Array(20).fill(0)),
+      randomBytes(8),
+    ])
+  ).toString("hex")}`;
+};
 
 export const shouldUseMatchForFulfill = () => true;

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -1,4 +1,5 @@
 import { BigNumber, BigNumberish, ethers } from "ethers";
+import { concat, keccak256, randomBytes, toUtf8Bytes } from "ethers/lib/utils";
 import { ItemType, ONE_HUNDRED_PERCENT_BP } from "../constants";
 import type {
   ConsiderationItem,
@@ -272,7 +273,11 @@ export const mapOrderAmountsFromUnitsToFill = (
 };
 
 export const generateRandomSalt = () => {
-  return `0x${Buffer.from(ethers.utils.randomBytes(16)).toString("hex")}`;
+  return `0x${Buffer.from(ethers.utils.randomBytes(12)).toString("hex").padStart(8, "0")}`;
 };
+
+export const generateRandomSaltWithDomain = (domain: string) => {
+  return `0x${Buffer.from(concat([keccak256(toUtf8Bytes(domain)).slice(2,10), randomBytes(8)])).toString("hex")}`;
+}
 
 export const shouldUseMatchForFulfill = () => true;


### PR DESCRIPTION
## Motivation
In order to attribute orders to their respective domains for analytics purposes, allow users to supply an optional `string domain` param when creating orders. The domain hash is included in the first four bytes of the arbitrary order salt. If no domain is supplied, first four bytes are empty (0x00000000).

## Solution
`generateRandomSaltWithDomain` returns a random salt with the supplied domain hashed and added to the first four bytes. 