### PR TITLE
Add hash of passed in domain to end of calldata

### DIFF
--- a/src/__tests__/ascending-descending-amounts.spec.ts
+++ b/src/__tests__/ascending-descending-amounts.spec.ts
@@ -31,6 +31,8 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
   const nftId = "1";
   const erc1155Amount = "5";
 
+  const GEM_DOMAIN = "gem.xyz";
+
   beforeEach(async () => {
     [offerer, zone, fulfiller] = await ethers.getSigners();
     multicallProvider = new providers.MulticallProvider(ethers.provider);
@@ -112,6 +114,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(1);
@@ -124,6 +127,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await action.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 
@@ -197,6 +204,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(2);
@@ -226,6 +234,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await fulfillAction.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 
@@ -320,6 +332,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(1);
@@ -332,6 +345,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await action.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 
@@ -404,6 +421,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(2);
@@ -433,6 +451,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await fulfillAction.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 
@@ -531,6 +553,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(1);
@@ -543,6 +566,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await action.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 
@@ -626,6 +653,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(2);
@@ -655,6 +683,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await fulfillAction.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 
@@ -761,6 +793,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(1);
@@ -773,6 +806,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await action.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 
@@ -855,6 +892,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         const { actions } = await seaport.fulfillOrder({
           order,
           accountAddress: fulfiller.address,
+          domain: GEM_DOMAIN,
         });
 
         expect(actions.length).to.eq(2);
@@ -884,6 +922,10 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
         });
 
         const transaction = await fulfillAction.transactionMethods.transact();
+
+        expect(transaction.data.slice(-8)).to.eq(
+          fulfill.getTagFromDomain(GEM_DOMAIN)
+        );
 
         const receipt = await transaction.wait();
 

--- a/src/__tests__/ascending-descending-amounts.spec.ts
+++ b/src/__tests__/ascending-descending-amounts.spec.ts
@@ -9,6 +9,7 @@ import { ItemType, MAX_INT, OrderType } from "../constants";
 import { CreateOrderInput, CurrencyItem } from "../types";
 import * as fulfill from "../utils/fulfill";
 import { generateRandomSalt } from "../utils/order";
+import { getTagFromDomain } from "../utils/usecase";
 import {
   getBalancesForFulfillOrder,
   verifyBalancesAfterFulfill,
@@ -128,9 +129,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await action.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 
@@ -235,9 +234,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await fulfillAction.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 
@@ -346,9 +343,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await action.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 
@@ -452,9 +447,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await fulfillAction.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 
@@ -567,9 +560,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await action.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 
@@ -684,9 +675,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await fulfillAction.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 
@@ -807,9 +796,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await action.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 
@@ -923,9 +910,7 @@ describeWithFixture("As a user I want to create a dutch auction", (fixture) => {
 
         const transaction = await fulfillAction.transactionMethods.transact();
 
-        expect(transaction.data.slice(-8)).to.eq(
-          fulfill.getTagFromDomain(GEM_DOMAIN)
-        );
+        expect(transaction.data.slice(-8)).to.eq(getTagFromDomain(GEM_DOMAIN));
 
         const receipt = await transaction.wait();
 

--- a/src/__tests__/basic-fulfill.spec.ts
+++ b/src/__tests__/basic-fulfill.spec.ts
@@ -25,6 +25,7 @@ describeWithFixture(
     let fulfillBasicOrderSpy: sinon.SinonSpy;
     const nftId = "1";
     const erc1155Amount = "3";
+    const OPENSEA_DOMAIN = "opensea.io";
 
     beforeEach(async () => {
       fulfillBasicOrderSpy = sinon.spy(fulfill, "fulfillBasicOrder");
@@ -85,6 +86,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             expect(actions.length).to.eq(1);
@@ -120,6 +122,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             const action = actions[0];
@@ -192,6 +195,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             const approvalAction = actions[0];
@@ -258,6 +262,7 @@ describeWithFixture(
             const revertedUseCase = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             const actions = revertedUseCase.actions;
@@ -359,6 +364,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -452,6 +458,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             const fulfillAction = actions[0];
@@ -490,6 +497,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             const fulfillAction = actions[0];
@@ -568,6 +576,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             const approvalAction = actions[0];
@@ -634,6 +643,7 @@ describeWithFixture(
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN,
             });
 
             const approvalAction = actions[0];
@@ -739,6 +749,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN,
           });
 
           const approvalAction = actions[0];

--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -32,6 +32,8 @@ describeWithFixture(
     const nftId2 = "2";
     const erc1155Amount = "3";
 
+    const ENS_VISION_DOMAIN = "ens.vision";
+
     beforeEach(async () => {
       [offerer, zone, fulfiller] = await ethers.getSigners();
       multicallProvider = new providers.MulticallProvider(ethers.provider);
@@ -109,6 +111,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           expect(actions.length).to.eq(1);
@@ -121,6 +124,11 @@ describeWithFixture(
           });
 
           const transaction = await action.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
+
           const receipt = await transaction.wait();
 
           await verifyBalancesAfterFulfill({
@@ -178,6 +186,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -208,6 +217,10 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
 
           const receipt = await transaction.wait();
 
@@ -296,6 +309,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -367,6 +381,10 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
 
           const receipt = await transaction.wait();
 
@@ -451,6 +469,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           expect(actions.length).to.eq(1);
@@ -460,6 +479,11 @@ describeWithFixture(
           expect(action.type).eq("exchange");
 
           const transaction = await action.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
+
           const receipt = await transaction.wait();
 
           await verifyBalancesAfterFulfill({
@@ -522,6 +546,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -552,6 +577,10 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
 
           const receipt = await transaction.wait();
 
@@ -646,6 +675,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -738,6 +768,10 @@ describeWithFixture(
 
           const transaction = await fulfillAction.transactionMethods.transact();
 
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
+
           const receipt = await transaction.wait();
 
           await verifyBalancesAfterFulfill({
@@ -829,6 +863,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           expect(actions.length).to.eq(1);
@@ -838,6 +873,11 @@ describeWithFixture(
           expect(action.type).eq("exchange");
 
           const transaction = await action.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
+
           const receipt = await transaction.wait();
 
           await verifyBalancesAfterFulfill({
@@ -896,6 +936,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -926,6 +967,10 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
 
           const receipt = await transaction.wait();
 
@@ -1018,6 +1063,7 @@ describeWithFixture(
           const { actions } = await seaport.fulfillOrder({
             order,
             accountAddress: fulfiller.address,
+            domain: ENS_VISION_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -1089,6 +1135,10 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(
+            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+          );
 
           const receipt = await transaction.wait();
 

--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -13,6 +13,7 @@ import {
   getBalancesForFulfillOrder,
   verifyBalancesAfterFulfill,
 } from "./utils/balance";
+import { getTagFromDomain } from "../utils/usecase";
 import { describeWithFixture } from "./utils/setup";
 
 describeWithFixture(
@@ -126,7 +127,7 @@ describeWithFixture(
           const transaction = await action.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -219,7 +220,7 @@ describeWithFixture(
           const transaction = await fulfillAction.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -383,7 +384,7 @@ describeWithFixture(
           const transaction = await fulfillAction.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -481,7 +482,7 @@ describeWithFixture(
           const transaction = await action.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -579,7 +580,7 @@ describeWithFixture(
           const transaction = await fulfillAction.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -769,7 +770,7 @@ describeWithFixture(
           const transaction = await fulfillAction.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -875,7 +876,7 @@ describeWithFixture(
           const transaction = await action.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -969,7 +970,7 @@ describeWithFixture(
           const transaction = await fulfillAction.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();
@@ -1137,7 +1138,7 @@ describeWithFixture(
           const transaction = await fulfillAction.transactionMethods.transact();
 
           expect(transaction.data.slice(-8)).to.eq(
-            fulfill.getTagFromDomain(ENS_VISION_DOMAIN)
+            getTagFromDomain(ENS_VISION_DOMAIN)
           );
 
           const receipt = await transaction.wait();

--- a/src/__tests__/fulfill-orders.spec.ts
+++ b/src/__tests__/fulfill-orders.spec.ts
@@ -29,8 +29,8 @@ describeWithFixture(
     const erc1155Amount = "3";
     const erc1155Amount2 = "7";
 
-    const OPENSEA_DOMAIN_HASH = "0x360c6ebe";
-    const OPENSEA_SUFFIX = "360c6ebe";
+    const OPENSEA_DOMAIN = "opensea.io";
+    const OPENSEA_TAG = "360c6ebe";
 
     beforeEach(async () => {
       fulfillAvailableOrdersSpy = sinon.spy(fulfill, "fulfillAvailableOrders");
@@ -145,7 +145,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
-              domain: OPENSEA_DOMAIN_HASH,
+              domain: OPENSEA_DOMAIN,
             });
 
             expect(actions.length).to.eq(1);
@@ -158,11 +158,11 @@ describeWithFixture(
               (await action.transactionMethods.buildTransaction()).data?.slice(
                 -8
               )
-            ).to.eq(OPENSEA_SUFFIX);
+            ).to.eq(OPENSEA_TAG);
 
             const transaction = await action.transactionMethods.transact();
 
-            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
             const owners = await Promise.all([
               testErc721.ownerOf(nftId),
@@ -244,7 +244,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
-              domain: OPENSEA_DOMAIN_HASH,
+              domain: OPENSEA_DOMAIN,
             });
 
             expect(actions.length).to.eq(2);
@@ -275,12 +275,12 @@ describeWithFixture(
               (
                 await fulfillAction.transactionMethods.buildTransaction()
               ).data?.slice(-8)
-            ).to.eq(OPENSEA_SUFFIX);
+            ).to.eq(OPENSEA_TAG);
 
             const transaction =
               await fulfillAction.transactionMethods.transact();
 
-            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
             const owners = await Promise.all([
               testErc721.ownerOf(nftId),
@@ -397,7 +397,7 @@ describeWithFixture(
               { order: thirdOrder },
             ],
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -471,11 +471,11 @@ describeWithFixture(
             (
               await fulfillAction.transactionMethods.buildTransaction()
             ).data?.slice(-8)
-          ).to.eq(OPENSEA_SUFFIX);
+          ).to.eq(OPENSEA_TAG);
 
           const transaction = await fulfillAction.transactionMethods.transact();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const owners = await Promise.all([
             testErc721.ownerOf(nftId),
@@ -596,7 +596,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
-              domain: OPENSEA_DOMAIN_HASH,
+              domain: OPENSEA_DOMAIN,
             });
 
             expect(actions.length).to.eq(1);
@@ -609,11 +609,11 @@ describeWithFixture(
               (await action.transactionMethods.buildTransaction()).data?.slice(
                 -8
               )
-            ).to.eq(OPENSEA_SUFFIX);
+            ).to.eq(OPENSEA_TAG);
 
             const transaction = await action.transactionMethods.transact();
 
-            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
             const balances = await Promise.all([
               testErc1155.balanceOf(fulfiller.address, nftId),
@@ -694,7 +694,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
-              domain: OPENSEA_DOMAIN_HASH,
+              domain: OPENSEA_DOMAIN,
             });
 
             expect(actions.length).to.eq(2);
@@ -725,12 +725,12 @@ describeWithFixture(
               (
                 await fulfillAction.transactionMethods.buildTransaction()
               ).data?.slice(-8)
-            ).to.eq(OPENSEA_SUFFIX);
+            ).to.eq(OPENSEA_TAG);
 
             const transaction =
               await fulfillAction.transactionMethods.transact();
 
-            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
             const balances = await Promise.all([
               testErc1155.balanceOf(fulfiller.address, nftId),
@@ -849,7 +849,7 @@ describeWithFixture(
               { order: thirdOrder },
             ],
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -923,11 +923,11 @@ describeWithFixture(
             (
               await fulfillAction.transactionMethods.buildTransaction()
             ).data?.slice(-8)
-          ).to.eq(OPENSEA_SUFFIX);
+          ).to.eq(OPENSEA_TAG);
 
           const transaction = await fulfillAction.transactionMethods.transact();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const balances = await Promise.all([
             testErc1155.balanceOf(offerer.address, nftId),

--- a/src/__tests__/fulfill-orders.spec.ts
+++ b/src/__tests__/fulfill-orders.spec.ts
@@ -29,6 +29,9 @@ describeWithFixture(
     const erc1155Amount = "3";
     const erc1155Amount2 = "7";
 
+    const OPENSEA_DOMAIN_HASH = "0x360c6ebe";
+    const OPENSEA_SUFFIX = "360c6ebe";
+
     beforeEach(async () => {
       fulfillAvailableOrdersSpy = sinon.spy(fulfill, "fulfillAvailableOrders");
 
@@ -142,6 +145,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN_HASH,
             });
 
             expect(actions.length).to.eq(1);
@@ -150,7 +154,15 @@ describeWithFixture(
 
             expect(action.type).eq("exchange");
 
-            await action.transactionMethods.transact();
+            expect(
+              (await action.transactionMethods.buildTransaction()).data?.slice(
+                -8
+              )
+            ).to.eq(OPENSEA_SUFFIX);
+
+            const transaction = await action.transactionMethods.transact();
+
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
             const owners = await Promise.all([
               testErc721.ownerOf(nftId),
@@ -232,6 +244,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN_HASH,
             });
 
             expect(actions.length).to.eq(2);
@@ -258,7 +271,16 @@ describeWithFixture(
 
             const fulfillAction = actions[1];
 
-            await fulfillAction.transactionMethods.transact();
+            expect(
+              (
+                await fulfillAction.transactionMethods.buildTransaction()
+              ).data?.slice(-8)
+            ).to.eq(OPENSEA_SUFFIX);
+
+            const transaction =
+              await fulfillAction.transactionMethods.transact();
+
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
             const owners = await Promise.all([
               testErc721.ownerOf(nftId),
@@ -375,6 +397,7 @@ describeWithFixture(
               { order: thirdOrder },
             ],
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           const approvalAction = actions[0];
@@ -444,7 +467,15 @@ describeWithFixture(
             transactionMethods: fulfillAction.transactionMethods,
           });
 
-          await fulfillAction.transactionMethods.transact();
+          expect(
+            (
+              await fulfillAction.transactionMethods.buildTransaction()
+            ).data?.slice(-8)
+          ).to.eq(OPENSEA_SUFFIX);
+
+          const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const owners = await Promise.all([
             testErc721.ownerOf(nftId),
@@ -565,6 +596,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN_HASH,
             });
 
             expect(actions.length).to.eq(1);
@@ -573,7 +605,15 @@ describeWithFixture(
 
             expect(action.type).eq("exchange");
 
-            await action.transactionMethods.transact();
+            expect(
+              (await action.transactionMethods.buildTransaction()).data?.slice(
+                -8
+              )
+            ).to.eq(OPENSEA_SUFFIX);
+
+            const transaction = await action.transactionMethods.transact();
+
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
             const balances = await Promise.all([
               testErc1155.balanceOf(fulfiller.address, nftId),
@@ -654,6 +694,7 @@ describeWithFixture(
                 { order: thirdOrder },
               ],
               accountAddress: fulfiller.address,
+              domain: OPENSEA_DOMAIN_HASH,
             });
 
             expect(actions.length).to.eq(2);
@@ -680,7 +721,16 @@ describeWithFixture(
 
             const fulfillAction = actions[1];
 
-            await fulfillAction.transactionMethods.transact();
+            expect(
+              (
+                await fulfillAction.transactionMethods.buildTransaction()
+              ).data?.slice(-8)
+            ).to.eq(OPENSEA_SUFFIX);
+
+            const transaction =
+              await fulfillAction.transactionMethods.transact();
+
+            expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
             const balances = await Promise.all([
               testErc1155.balanceOf(fulfiller.address, nftId),
@@ -799,6 +849,7 @@ describeWithFixture(
               { order: thirdOrder },
             ],
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           const approvalAction = actions[0];
@@ -868,7 +919,15 @@ describeWithFixture(
             transactionMethods: fulfillAction.transactionMethods,
           });
 
-          await fulfillAction.transactionMethods.transact();
+          expect(
+            (
+              await fulfillAction.transactionMethods.buildTransaction()
+            ).data?.slice(-8)
+          ).to.eq(OPENSEA_SUFFIX);
+
+          const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const balances = await Promise.all([
             testErc1155.balanceOf(offerer.address, nftId),

--- a/src/__tests__/partial-fulfill.spec.ts
+++ b/src/__tests__/partial-fulfill.spec.ts
@@ -29,8 +29,8 @@ describeWithFixture(
 
     const nftId = "1";
 
-    const OPENSEA_DOMAIN_HASH = "0x360c6ebe";
-    const OPENSEA_SUFFIX = "360c6ebe";
+    const OPENSEA_DOMAIN = "opensea.io";
+    const OPENSEA_TAG = "360c6ebe";
 
     beforeEach(async () => {
       [offerer, zone, fulfiller] = await ethers.getSigners();
@@ -103,7 +103,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           expect(actions.length).to.eq(1);
@@ -119,7 +119,7 @@ describeWithFixture(
 
           const receipt = await transaction.wait();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const offererErc1155Balance = await testErc1155.balanceOf(
             offerer.address,
@@ -188,7 +188,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           expect(actions.length).to.eq(2);
@@ -222,7 +222,7 @@ describeWithFixture(
 
           const transaction = await fulfillAction.transactionMethods.transact();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const receipt = await transaction.wait();
 
@@ -312,7 +312,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -365,7 +365,7 @@ describeWithFixture(
 
           const transaction = await fulfillAction.transactionMethods.transact();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const receipt = await transaction.wait();
 
@@ -461,7 +461,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           expect(actions.length).to.eq(1);
@@ -475,7 +475,7 @@ describeWithFixture(
 
           const transaction = await action.transactionMethods.transact();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const receipt = await transaction.wait();
 
@@ -556,7 +556,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           expect(actions.length).to.eq(2);
@@ -590,7 +590,7 @@ describeWithFixture(
 
           const transaction = await fulfillAction.transactionMethods.transact();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const receipt = await transaction.wait();
 
@@ -698,7 +698,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
-            domain: OPENSEA_DOMAIN_HASH,
+            domain: OPENSEA_DOMAIN,
           });
 
           const approvalAction = actions[0];
@@ -771,7 +771,7 @@ describeWithFixture(
 
           const transaction = await fulfillAction.transactionMethods.transact();
 
-          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
 
           const receipt = await transaction.wait();
 

--- a/src/__tests__/partial-fulfill.spec.ts
+++ b/src/__tests__/partial-fulfill.spec.ts
@@ -29,6 +29,9 @@ describeWithFixture(
 
     const nftId = "1";
 
+    const OPENSEA_DOMAIN_HASH = "0x360c6ebe";
+    const OPENSEA_SUFFIX = "360c6ebe";
+
     beforeEach(async () => {
       [offerer, zone, fulfiller] = await ethers.getSigners();
       multicallProvider = new providers.MulticallProvider(ethers.provider);
@@ -100,6 +103,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           expect(actions.length).to.eq(1);
@@ -114,6 +118,8 @@ describeWithFixture(
           const transaction = await action.transactionMethods.transact();
 
           const receipt = await transaction.wait();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const offererErc1155Balance = await testErc1155.balanceOf(
             offerer.address,
@@ -182,6 +188,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           expect(actions.length).to.eq(2);
@@ -214,6 +221,8 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const receipt = await transaction.wait();
 
@@ -303,6 +312,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           const approvalAction = actions[0];
@@ -354,6 +364,8 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const receipt = await transaction.wait();
 
@@ -449,6 +461,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           expect(actions.length).to.eq(1);
@@ -461,6 +474,8 @@ describeWithFixture(
           });
 
           const transaction = await action.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const receipt = await transaction.wait();
 
@@ -541,6 +556,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           expect(actions.length).to.eq(2);
@@ -573,6 +589,8 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const receipt = await transaction.wait();
 
@@ -680,6 +698,7 @@ describeWithFixture(
             order,
             unitsToFill: 2,
             accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN_HASH,
           });
 
           const approvalAction = actions[0];
@@ -751,6 +770,8 @@ describeWithFixture(
           });
 
           const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_SUFFIX);
 
           const receipt = await transaction.wait();
 

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -416,13 +416,17 @@ export class Seaport {
    */
   public cancelOrders(
     orders: OrderComponents[],
-    accountAddress?: string
+    accountAddress?: string,
+    suffix?: string
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "cancel">> {
     const signer = this._getSigner(accountAddress);
 
-    return getTransactionMethods(this.contract.connect(signer), "cancel", [
-      orders,
-    ]);
+    return getTransactionMethods(
+      this.contract.connect(signer),
+      "cancel",
+      [orders],
+      suffix
+    );
   }
 
   /**
@@ -431,7 +435,8 @@ export class Seaport {
    * @returns the set of transaction methods that can be used
    */
   public bulkCancelOrders(
-    offerer?: string
+    offerer?: string,
+    suffix?: string
   ): TransactionMethods<
     ContractMethodReturnType<SeaportContract, "incrementCounter">
   > {
@@ -440,7 +445,8 @@ export class Seaport {
     return getTransactionMethods(
       this.contract.connect(signer),
       "incrementCounter",
-      []
+      [],
+      suffix
     );
   }
 
@@ -453,13 +459,17 @@ export class Seaport {
    */
   public validate(
     orders: Order[],
-    accountAddress?: string
+    accountAddress?: string,
+    suffix?: string
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "validate">> {
     const signer = this._getSigner(accountAddress);
 
-    return getTransactionMethods(this.contract.connect(signer), "validate", [
-      orders,
-    ]);
+    return getTransactionMethods(
+      this.contract.connect(signer),
+      "validate",
+      [orders],
+      suffix
+    );
   }
 
   /**

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -909,29 +909,30 @@ export class Seaport {
    * @param input.accountAddress Optional address for which to match the order with
    * @returns set of transaction methods for matching orders
    */
-  public matchOrders(
-    {
-      orders,
-      fulfillments,
-      overrides,
-      accountAddress,
-    }: {
-      orders: (OrderWithCounter | Order)[];
-      fulfillments: MatchOrdersFulfillment[];
-      overrides?: PayableOverrides;
-      accountAddress?: string;
-    },
-    domain?: string
-  ): TransactionMethods<
+  public matchOrders({
+    orders,
+    fulfillments,
+    overrides,
+    accountAddress,
+    domain = "",
+  }: {
+    orders: (OrderWithCounter | Order)[];
+    fulfillments: MatchOrdersFulfillment[];
+    overrides?: PayableOverrides;
+    accountAddress?: string;
+    domain?: string;
+  }): TransactionMethods<
     ContractMethodReturnType<SeaportContract, "matchOrders">
   > {
     const signer = this._getSigner(accountAddress);
+
+    const tag = domain ? getTagFromDomain(domain) : "";
 
     return getTransactionMethods(
       this.contract.connect(signer),
       "matchOrders",
       [orders, fulfillments, overrides],
-      domain
+      tag
     );
   }
 }

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -636,6 +636,7 @@ export class Seaport {
     accountAddress,
     conduitKey = this.defaultConduitKey,
     recipientAddress = ethers.constants.AddressZero,
+    suffix = "",
   }: {
     order: OrderWithCounter;
     unitsToFill?: BigNumberish;
@@ -646,6 +647,7 @@ export class Seaport {
     accountAddress?: string;
     conduitKey?: string;
     recipientAddress?: string;
+    suffix?: string;
   }): Promise<
     OrderUseCase<
       ExchangeAction<
@@ -737,6 +739,7 @@ export class Seaport {
         fulfillerOperator,
         signer: fulfiller,
         tips: tipConsiderationItems,
+        suffix,
       });
     }
 
@@ -761,6 +764,7 @@ export class Seaport {
       offererOperator,
       fulfillerOperator,
       recipientAddress,
+      suffix,
     });
   }
 
@@ -780,6 +784,7 @@ export class Seaport {
     accountAddress,
     conduitKey = this.defaultConduitKey,
     recipientAddress = ethers.constants.AddressZero,
+    suffix = "",
   }: {
     fulfillOrderDetails: {
       order: OrderWithCounter;
@@ -792,6 +797,7 @@ export class Seaport {
     accountAddress?: string;
     conduitKey?: string;
     recipientAddress?: string;
+    suffix?: string;
   }) {
     const fulfiller = this._getSigner(accountAddress);
 
@@ -881,6 +887,7 @@ export class Seaport {
       signer: fulfiller,
       conduitKey,
       recipientAddress,
+      suffix,
     });
   }
 
@@ -895,25 +902,29 @@ export class Seaport {
    * @param input.accountAddress Optional address for which to match the order with
    * @returns set of transaction methods for matching orders
    */
-  public matchOrders({
-    orders,
-    fulfillments,
-    overrides,
-    accountAddress,
-  }: {
-    orders: (OrderWithCounter | Order)[];
-    fulfillments: MatchOrdersFulfillment[];
-    overrides?: PayableOverrides;
-    accountAddress?: string;
-  }): TransactionMethods<
+  public matchOrders(
+    {
+      orders,
+      fulfillments,
+      overrides,
+      accountAddress,
+    }: {
+      orders: (OrderWithCounter | Order)[];
+      fulfillments: MatchOrdersFulfillment[];
+      overrides?: PayableOverrides;
+      accountAddress?: string;
+    },
+    suffix?: string
+  ): TransactionMethods<
     ContractMethodReturnType<SeaportContract, "matchOrders">
   > {
     const signer = this._getSigner(accountAddress);
 
-    return getTransactionMethods(this.contract.connect(signer), "matchOrders", [
-      orders,
-      fulfillments,
-      overrides,
-    ]);
+    return getTransactionMethods(
+      this.contract.connect(signer),
+      "matchOrders",
+      [orders, fulfillments, overrides],
+      suffix
+    );
   }
 }

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -412,6 +412,7 @@ export class Seaport {
    *
    * @param orders list of order components
    * @param accountAddress optional account address from which to cancel the orders from.
+   * @param domain optional domain to be hashed and appended to calldata
    * @returns the set of transaction methods that can be used
    */
   public cancelOrders(
@@ -432,6 +433,7 @@ export class Seaport {
   /**
    * Bulk cancels all existing orders for a given account
    * @param offerer the account to bulk cancel orders on
+   * @param domain optional domain to be hashed and appended to calldata
    * @returns the set of transaction methods that can be used
    */
   public bulkCancelOrders(
@@ -455,6 +457,7 @@ export class Seaport {
    * a signature. Can also check if an order is valid using `callStatic`
    * @param orders list of order structs
    * @param accountAddress optional account address to approve orders.
+   * @param domain optional domain to be hashed and appended to calldata
    * @returns the set of transaction methods that can be used
    */
   public validate(
@@ -624,6 +627,7 @@ export class Seaport {
    * @param input.conduitKey the conduitKey to source approvals from
    * @param input.recipientAddress optional recipient to forward the offer to as opposed to the fulfiller.
    *                               Defaults to the zero address which means the offer goes to the fulfiller
+   * @param input.domain optional domain to be hashed and appended to calldata
    * @returns a use case containing the set of approval actions and fulfillment action
    */
   public async fulfillOrder({
@@ -777,6 +781,7 @@ export class Seaport {
    * @param input.conduitKey the key from which to source approvals from
    * @param input.recipientAddress optional recipient to forward the offer to as opposed to the fulfiller.
    *                               Defaults to the zero address which means the offer goes to the fulfiller
+   * @param input.domain optional domain to be hashed and appended to calldata
    * @returns a use case containing the set of approval actions and fulfillment action
    */
   public async fulfillOrders({
@@ -900,6 +905,7 @@ export class Seaport {
    * @param input.fulfillments the list of fulfillments to match offer and considerations
    * @param input.overrides any overrides the client wants, will need to pass in value for matching orders with ETH.
    * @param input.accountAddress Optional address for which to match the order with
+   * @param input.domain optional domain to be hashed and appended to calldata
    * @returns set of transaction methods for matching orders
    */
   public matchOrders({

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -48,6 +48,7 @@ import {
   fulfillBasicOrder,
   FulfillOrdersMetadata,
   fulfillStandardOrder,
+  getTagFromDomain,
   shouldUseBasicFulfill,
   validateAndSanitizeFromOrderStatus,
 } from "./utils/fulfill";
@@ -421,11 +422,13 @@ export class Seaport {
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "cancel">> {
     const signer = this._getSigner(accountAddress);
 
+    const tag = domain ? getTagFromDomain(domain) : "";
+
     return getTransactionMethods(
       this.contract.connect(signer),
       "cancel",
       [orders],
-      domain
+      tag
     );
   }
 
@@ -442,11 +445,13 @@ export class Seaport {
   > {
     const signer = this._getSigner(offerer);
 
+    const tag = domain ? getTagFromDomain(domain) : "";
+
     return getTransactionMethods(
       this.contract.connect(signer),
       "incrementCounter",
       [],
-      domain
+      tag
     );
   }
 
@@ -464,11 +469,13 @@ export class Seaport {
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "validate">> {
     const signer = this._getSigner(accountAddress);
 
+    const tag = domain ? getTagFromDomain(domain) : "";
+
     return getTransactionMethods(
       this.contract.connect(signer),
       "validate",
       [orders],
-      domain
+      tag
     );
   }
 

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -417,7 +417,7 @@ export class Seaport {
   public cancelOrders(
     orders: OrderComponents[],
     accountAddress?: string,
-    suffix?: string
+    domain?: string
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "cancel">> {
     const signer = this._getSigner(accountAddress);
 
@@ -425,7 +425,7 @@ export class Seaport {
       this.contract.connect(signer),
       "cancel",
       [orders],
-      suffix
+      domain
     );
   }
 
@@ -436,7 +436,7 @@ export class Seaport {
    */
   public bulkCancelOrders(
     offerer?: string,
-    suffix?: string
+    domain?: string
   ): TransactionMethods<
     ContractMethodReturnType<SeaportContract, "incrementCounter">
   > {
@@ -446,7 +446,7 @@ export class Seaport {
       this.contract.connect(signer),
       "incrementCounter",
       [],
-      suffix
+      domain
     );
   }
 
@@ -460,7 +460,7 @@ export class Seaport {
   public validate(
     orders: Order[],
     accountAddress?: string,
-    suffix?: string
+    domain?: string
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "validate">> {
     const signer = this._getSigner(accountAddress);
 
@@ -468,7 +468,7 @@ export class Seaport {
       this.contract.connect(signer),
       "validate",
       [orders],
-      suffix
+      domain
     );
   }
 
@@ -636,7 +636,7 @@ export class Seaport {
     accountAddress,
     conduitKey = this.defaultConduitKey,
     recipientAddress = ethers.constants.AddressZero,
-    suffix = "",
+    domain = "",
   }: {
     order: OrderWithCounter;
     unitsToFill?: BigNumberish;
@@ -647,7 +647,7 @@ export class Seaport {
     accountAddress?: string;
     conduitKey?: string;
     recipientAddress?: string;
-    suffix?: string;
+    domain?: string;
   }): Promise<
     OrderUseCase<
       ExchangeAction<
@@ -739,7 +739,7 @@ export class Seaport {
         fulfillerOperator,
         signer: fulfiller,
         tips: tipConsiderationItems,
-        suffix,
+        domain,
       });
     }
 
@@ -764,7 +764,7 @@ export class Seaport {
       offererOperator,
       fulfillerOperator,
       recipientAddress,
-      suffix,
+      domain,
     });
   }
 
@@ -784,7 +784,7 @@ export class Seaport {
     accountAddress,
     conduitKey = this.defaultConduitKey,
     recipientAddress = ethers.constants.AddressZero,
-    suffix = "",
+    domain = "",
   }: {
     fulfillOrderDetails: {
       order: OrderWithCounter;
@@ -797,7 +797,7 @@ export class Seaport {
     accountAddress?: string;
     conduitKey?: string;
     recipientAddress?: string;
-    suffix?: string;
+    domain?: string;
   }) {
     const fulfiller = this._getSigner(accountAddress);
 
@@ -887,7 +887,7 @@ export class Seaport {
       signer: fulfiller,
       conduitKey,
       recipientAddress,
-      suffix,
+      domain,
     });
   }
 
@@ -914,7 +914,7 @@ export class Seaport {
       overrides?: PayableOverrides;
       accountAddress?: string;
     },
-    suffix?: string
+    domain?: string
   ): TransactionMethods<
     ContractMethodReturnType<SeaportContract, "matchOrders">
   > {
@@ -924,7 +924,7 @@ export class Seaport {
       this.contract.connect(signer),
       "matchOrders",
       [orders, fulfillments, overrides],
-      suffix
+      domain
     );
   }
 }

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -48,7 +48,6 @@ import {
   fulfillBasicOrder,
   FulfillOrdersMetadata,
   fulfillStandardOrder,
-  getTagFromDomain,
   shouldUseBasicFulfill,
   validateAndSanitizeFromOrderStatus,
 } from "./utils/fulfill";
@@ -422,13 +421,11 @@ export class Seaport {
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "cancel">> {
     const signer = this._getSigner(accountAddress);
 
-    const tag = domain ? getTagFromDomain(domain) : "";
-
     return getTransactionMethods(
       this.contract.connect(signer),
       "cancel",
       [orders],
-      tag
+      domain
     );
   }
 
@@ -445,13 +442,11 @@ export class Seaport {
   > {
     const signer = this._getSigner(offerer);
 
-    const tag = domain ? getTagFromDomain(domain) : "";
-
     return getTransactionMethods(
       this.contract.connect(signer),
       "incrementCounter",
       [],
-      tag
+      domain
     );
   }
 
@@ -469,13 +464,11 @@ export class Seaport {
   ): TransactionMethods<ContractMethodReturnType<SeaportContract, "validate">> {
     const signer = this._getSigner(accountAddress);
 
-    const tag = domain ? getTagFromDomain(domain) : "";
-
     return getTransactionMethods(
       this.contract.connect(signer),
       "validate",
       [orders],
-      tag
+      domain
     );
   }
 
@@ -926,13 +919,11 @@ export class Seaport {
   > {
     const signer = this._getSigner(accountAddress);
 
-    const tag = domain ? getTagFromDomain(domain) : "";
-
     return getTransactionMethods(
       this.contract.connect(signer),
       "matchOrders",
       [orders, fulfillments, overrides],
-      tag
+      domain
     );
   }
 }

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -848,5 +848,5 @@ export const getAdvancedOrderNumeratorDenominator = (
 };
 
 export const getTagFromDomain = (domain: string) => {
-  return keccak256(toUtf8Bytes(domain)).slice(0, 10).replace(/^(0x)/, "");
+  return keccak256(toUtf8Bytes(domain)).slice(2, 10);
 };

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -5,7 +5,6 @@ import {
   ethers,
   Signer,
 } from "ethers";
-import { keccak256, toUtf8Bytes } from "ethers/lib/utils";
 import type {
   Seaport as SeaportContract,
   BasicOrderParametersStruct,
@@ -290,15 +289,13 @@ export async function fulfillBasicOrder({
     signer
   );
 
-  const tag = domain ? getTagFromDomain(domain) : "";
-
   const exchangeAction = {
     type: "exchange",
     transactionMethods: getTransactionMethods(
       seaportContract.connect(signer),
       "fulfillBasicOrder",
       [basicOrderParameters, payableOverrides],
-      tag
+      domain
     ),
   } as const;
 
@@ -445,8 +442,6 @@ export async function fulfillStandardOrder({
     unitsToFill
   );
 
-  const tag = domain ? getTagFromDomain(domain) : "";
-
   const exchangeAction = {
     type: "exchange",
     transactionMethods: useAdvanced
@@ -471,13 +466,13 @@ export async function fulfillStandardOrder({
             recipientAddress,
             payableOverrides,
           ],
-          tag
+          domain
         )
       : getTransactionMethods(
           seaportContract.connect(signer),
           "fulfillOrder",
           [orderAccountingForTips, conduitKey, payableOverrides],
-          tag
+          domain
         ),
   } as const;
 
@@ -702,8 +697,6 @@ export async function fulfillAvailableOrders({
   const { offerFulfillments, considerationFulfillments } =
     generateFulfillOrdersFulfillments(ordersMetadata);
 
-  const tag = domain ? getTagFromDomain(domain) : "";
-
   const exchangeAction = {
     type: "exchange",
     transactionMethods: getTransactionMethods(
@@ -729,7 +722,7 @@ export async function fulfillAvailableOrders({
         advancedOrdersWithTips.length,
         payableOverrides,
       ],
-      tag
+      domain
     ),
   } as const;
 
@@ -845,8 +838,4 @@ export const getAdvancedOrderNumeratorDenominator = (
   const denominator = unitsToFill ? maxUnits.div(unitsGcd) : BigNumber.from(1);
 
   return { numerator, denominator };
-};
-
-export const getTagFromDomain = (domain: string) => {
-  return keccak256(toUtf8Bytes(domain)).slice(2, 10);
 };

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -189,6 +189,7 @@ export async function fulfillBasicOrder({
   signer,
   tips = [],
   conduitKey = NO_CONDUIT,
+  suffix = "",
 }: {
   order: Order;
   seaportContract: Seaport;
@@ -325,6 +326,7 @@ export async function fulfillStandardOrder({
   conduitKey,
   recipientAddress,
   signer,
+  suffix = "",
 }: {
   order: Order;
   unitsToFill?: BigNumberish;
@@ -527,6 +529,7 @@ export async function fulfillAvailableOrders({
   conduitKey,
   signer,
   recipientAddress,
+  suffix = "",
 }: {
   ordersMetadata: FulfillOrdersMetadata;
   seaportContract: Seaport;
@@ -537,6 +540,7 @@ export async function fulfillAvailableOrders({
   conduitKey: string;
   signer: Signer;
   recipientAddress: string;
+  suffix?: string;
 }): Promise<
   OrderUseCase<
     ExchangeAction<

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -200,6 +200,7 @@ export async function fulfillBasicOrder({
   signer: Signer;
   tips?: ConsiderationItem[];
   conduitKey: string;
+  suffix?: string;
 }): Promise<
   OrderUseCase<
     ExchangeAction<
@@ -292,7 +293,8 @@ export async function fulfillBasicOrder({
     transactionMethods: getTransactionMethods(
       seaportContract.connect(signer),
       "fulfillBasicOrder",
-      [basicOrderParameters, payableOverrides]
+      [basicOrderParameters, payableOverrides],
+      suffix
     ),
   } as const;
 
@@ -341,6 +343,7 @@ export async function fulfillStandardOrder({
   recipientAddress: string;
   timeBasedItemParams: TimeBasedItemParams;
   signer: Signer;
+  suffix?: string;
 }): Promise<
   OrderUseCase<
     ExchangeAction<
@@ -460,13 +463,15 @@ export async function fulfillStandardOrder({
             conduitKey,
             recipientAddress,
             payableOverrides,
-          ]
+          ],
+          suffix
         )
-      : getTransactionMethods(seaportContract.connect(signer), "fulfillOrder", [
-          orderAccountingForTips,
-          conduitKey,
-          payableOverrides,
-        ]),
+      : getTransactionMethods(
+          seaportContract.connect(signer),
+          "fulfillOrder",
+          [orderAccountingForTips, conduitKey, payableOverrides],
+          suffix
+        ),
   } as const;
 
   const actions = [...approvalActions, exchangeAction] as const;
@@ -712,7 +717,8 @@ export async function fulfillAvailableOrders({
         recipientAddress,
         advancedOrdersWithTips.length,
         payableOverrides,
-      ]
+      ],
+      suffix
     ),
   } as const;
 

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -189,7 +189,7 @@ export async function fulfillBasicOrder({
   signer,
   tips = [],
   conduitKey = NO_CONDUIT,
-  suffix = "",
+  domain = "",
 }: {
   order: Order;
   seaportContract: Seaport;
@@ -201,7 +201,7 @@ export async function fulfillBasicOrder({
   signer: Signer;
   tips?: ConsiderationItem[];
   conduitKey: string;
-  suffix?: string;
+  domain?: string;
 }): Promise<
   OrderUseCase<
     ExchangeAction<
@@ -295,7 +295,7 @@ export async function fulfillBasicOrder({
       seaportContract.connect(signer),
       "fulfillBasicOrder",
       [basicOrderParameters, payableOverrides],
-      suffix
+      domain
     ),
   } as const;
 
@@ -326,7 +326,7 @@ export async function fulfillStandardOrder({
   conduitKey,
   recipientAddress,
   signer,
-  suffix = "",
+  domain = "",
 }: {
   order: Order;
   unitsToFill?: BigNumberish;
@@ -345,7 +345,7 @@ export async function fulfillStandardOrder({
   recipientAddress: string;
   timeBasedItemParams: TimeBasedItemParams;
   signer: Signer;
-  suffix?: string;
+  domain?: string;
 }): Promise<
   OrderUseCase<
     ExchangeAction<
@@ -466,13 +466,13 @@ export async function fulfillStandardOrder({
             recipientAddress,
             payableOverrides,
           ],
-          suffix
+          domain
         )
       : getTransactionMethods(
           seaportContract.connect(signer),
           "fulfillOrder",
           [orderAccountingForTips, conduitKey, payableOverrides],
-          suffix
+          domain
         ),
   } as const;
 
@@ -529,7 +529,7 @@ export async function fulfillAvailableOrders({
   conduitKey,
   signer,
   recipientAddress,
-  suffix = "",
+  domain = "",
 }: {
   ordersMetadata: FulfillOrdersMetadata;
   seaportContract: Seaport;
@@ -540,7 +540,7 @@ export async function fulfillAvailableOrders({
   conduitKey: string;
   signer: Signer;
   recipientAddress: string;
-  suffix?: string;
+  domain?: string;
 }): Promise<
   OrderUseCase<
     ExchangeAction<
@@ -722,7 +722,7 @@ export async function fulfillAvailableOrders({
         advancedOrdersWithTips.length,
         payableOverrides,
       ],
-      suffix
+      domain
     ),
   } as const;
 

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -848,7 +848,5 @@ export const getAdvancedOrderNumeratorDenominator = (
 };
 
 export const getTagFromDomain = (domain: string) => {
-  console.log(keccak256(toUtf8Bytes(domain)).slice(0, 10).replace(/^(0x)/, ""));
-
   return keccak256(toUtf8Bytes(domain)).slice(0, 10).replace(/^(0x)/, "");
 };

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -1,4 +1,5 @@
 import { CallOverrides, Contract, Overrides, PayableOverrides } from "ethers";
+import { keccak256, toUtf8Bytes } from "ethers/lib/utils";
 
 import {
   CreateOrderAction,
@@ -61,7 +62,7 @@ export const getTransactionMethods = <
   contract: T,
   method: U,
   args: Parameters<T["functions"][U]>,
-  tag: string = ""
+  domain: string = ""
 ): TransactionMethods<ContractMethodReturnType<T, U>> => {
   const lastArg = args[args.length - 1];
 
@@ -77,6 +78,9 @@ export const getTransactionMethods = <
     const populatedTransaction = await contract.populateTransaction[
       method as string
     ](...[...args, mergedOverrides]);
+
+    const tag = getTagFromDomain(domain);
+
     populatedTransaction.data = populatedTransaction.data + tag;
     return populatedTransaction;
   };
@@ -105,4 +109,8 @@ export const getTransactionMethods = <
     },
     buildTransaction,
   };
+};
+
+export const getTagFromDomain = (domain: string) => {
+  return keccak256(toUtf8Bytes(domain)).slice(2, 10);
 };

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -1,4 +1,24 @@
-import { CallOverrides, Contract, Overrides, PayableOverrides } from "ethers";
+import {
+  BigNumber,
+  CallOverrides,
+  Contract,
+  Overrides,
+  PayableOverrides,
+  PopulatedTransaction,
+  Signer,
+} from "ethers";
+import { providers } from "ethers";
+import {
+  accessListify,
+  arrayify,
+  getAddress,
+  FunctionFragment,
+  Logger,
+  resolveProperties,
+  shallowCopy,
+} from "ethers/lib/utils";
+import { version } from "ethers";
+
 import {
   CreateOrderAction,
   ExchangeAction,
@@ -6,6 +26,8 @@ import {
   TransactionMethods,
   ContractMethodReturnType,
 } from "../types";
+
+const logger = new Logger(version);
 
 export const executeAllActions = async <
   T extends CreateOrderAction | ExchangeAction
@@ -59,7 +81,8 @@ export const getTransactionMethods = <
 >(
   contract: T,
   method: U,
-  args: Parameters<T["functions"][U]>
+  args: Parameters<T["functions"][U]>,
+  suffix?: string
 ): TransactionMethods<ContractMethodReturnType<T, U>> => {
   const lastArg = args[args.length - 1];
 
@@ -94,8 +117,191 @@ export const getTransactionMethods = <
       const mergedOverrides = { ...initialOverrides, ...overrides };
 
       return contract.populateTransaction[method as string](
-        ...[...args, mergedOverrides]
+        contract,
+        [args],
+        suffix
       );
     },
   };
 };
+
+async function populateTransaction(
+  contract: Contract,
+  fragment: FunctionFragment,
+  args: Array<any>,
+  suffix: string
+): Promise<PopulatedTransaction> {
+  // // If an extra argument is given, it is overrides
+  // let overrides: CallOverrides = {};
+  // if (
+  //   args.length === fragment.inputs.length + 1 &&
+  //   typeof args[args.length - 1] === "object"
+  // ) {
+  //   overrides = shallowCopy(args.pop());
+  // }
+
+  // Make sure the parameter count matches
+  logger.checkArgumentCount(
+    args.length,
+    fragment.inputs.length,
+    "passed to contract"
+  );
+
+  // Populate "from" override (allow promises)
+  // if (contract.signer) {
+  //   if (overrides.from) {
+  //     // Contracts with a Signer are from the Signer's frame-of-reference;
+  //     // but we allow overriding "from" if it matches the signer
+  //     overrides.from = resolveProperties({
+  //       override: resolveName(contract.signer, overrides.from),
+  //       signer: contract.signer.getAddress(),
+  //     }).then(async (check) => {
+  //       if (getAddress(check.signer) !== check.override) {
+  //         logger.throwError(
+  //           "Contract with a Signer cannot override from",
+  //           Logger.errors.UNSUPPORTED_OPERATION,
+  //           {
+  //             operation: "overrides.from",
+  //           }
+  //         );
+  //       }
+
+  //       return check.override;
+  //     });
+  //   } else {
+  //     overrides.from = contract.signer.getAddress();
+  //   }
+  // } else if (overrides.from) {
+  //   overrides.from = resolveName(contract.provider, overrides.from);
+
+  //   //} else {
+  //   // Contracts without a signer can override "from", and if
+  //   // unspecified the zero address is used
+  //   //overrides.from = AddressZero;
+  // }
+
+  // // Wait for all dependencies to be resolved (prefer the signer over the provider)
+  // const resolved = await resolveProperties({
+  //   args: resolveAddresses(
+  //     contract.signer || contract.provider,
+  //     args,
+  //     fragment.inputs
+  //   ),
+  //   address: contract.resolvedAddress,
+  //   overrides: resolveProperties(overrides) || {},
+  // });
+
+  // The ABI coded transaction
+  const data = contract.interface.encodeFunctionData(fragment, args) + suffix;
+  console.log("data: ", data);
+  const tx: PopulatedTransaction = {
+    data: data,
+    to: contract.address,
+  };
+
+  // Resolved Overrides
+  // const ro = resolved.overrides;
+
+  // // Populate simple overrides
+  // if (ro.nonce != null) {
+  //   tx.nonce = BigNumber.from(ro.nonce).toNumber();
+  // }
+  // if (ro.gasLimit != null) {
+  //   tx.gasLimit = BigNumber.from(ro.gasLimit);
+  // }
+  // if (ro.gasPrice != null) {
+  //   tx.gasPrice = BigNumber.from(ro.gasPrice);
+  // }
+  // if (ro.maxFeePerGas != null) {
+  //   tx.maxFeePerGas = BigNumber.from(ro.maxFeePerGas);
+  // }
+  // if (ro.maxPriorityFeePerGas != null) {
+  //   tx.maxPriorityFeePerGas = BigNumber.from(ro.maxPriorityFeePerGas);
+  // }
+  // if (ro.from != null) {
+  //   tx.from = ro.from;
+  // }
+
+  // if (ro.type != null) {
+  //   tx.type = ro.type;
+  // }
+  // if (ro.accessList != null) {
+  //   tx.accessList = accessListify(ro.accessList);
+  // }
+
+  // // If there was no "gasLimit" override, but the ABI specifies a default, use it
+  // if (tx.gasLimit == null && fragment.gas != null) {
+  //   // Compute the intrinsic gas cost for this transaction
+  //   // @TODO: This is based on the yellow paper as of Petersburg; this is something
+  //   // we may wish to parameterize in v6 as part of the Network object. Since this
+  //   // is always a non-nil to address, we can ignore G_create, but may wish to add
+  //   // similar logic to the ContractFactory.
+  //   let intrinsic = 21000;
+  //   const bytes = arrayify(data);
+  //   for (let i = 0; i < bytes.length; i++) {
+  //     intrinsic += 4;
+  //     if (bytes[i]) {
+  //       intrinsic += 64;
+  //     }
+  //   }
+  //   tx.gasLimit = BigNumber.from(fragment.gas).add(intrinsic);
+  // }
+
+  // Populate "value" override
+  // if (ro.value) {
+  //   const roValue = BigNumber.from(ro.value);
+  //   if (!roValue.isZero() && !fragment.payable) {
+  //     logger.throwError(
+  //       "non-payable method cannot override value",
+  //       Logger.errors.UNSUPPORTED_OPERATION,
+  //       {
+  //         operation: "overrides.value",
+  //         value: overrides.value,
+  //       }
+  //     );
+  //   }
+  //   tx.value = roValue;
+  // }
+
+  // if (ro.customData) {
+  //   tx.customData = shallowCopy(ro.customData);
+  // }
+
+  // if (ro.ccipReadEnabled) {
+  //   tx.ccipReadEnabled = !!ro.ccipReadEnabled;
+  // }
+
+  // // Remove the overrides
+  // delete overrides.nonce;
+  // delete overrides.gasLimit;
+  // delete overrides.gasPrice;
+  // delete overrides.from;
+  // delete overrides.value;
+
+  // delete overrides.type;
+  // delete overrides.accessList;
+
+  // delete overrides.maxFeePerGas;
+  // delete overrides.maxPriorityFeePerGas;
+
+  // delete overrides.customData;
+  // delete overrides.ccipReadEnabled;
+
+  // Make sure there are no stray overrides, which may indicate a
+  // // typo or using an unsupported key.
+  // const leftovers = Object.keys(overrides).filter(
+  //   (key) => (<any>overrides)[key] != null
+  // );
+  // if (leftovers.length) {
+  //   logger.throwError(
+  //     `cannot override ${leftovers.map((l) => JSON.stringify(l)).join(",")}`,
+  //     Logger.errors.UNSUPPORTED_OPERATION,
+  //     {
+  //       operation: "overrides",
+  //       overrides: leftovers,
+  //     }
+  //   );
+  // }
+
+  return tx;
+}

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -61,7 +61,7 @@ export const getTransactionMethods = <
   contract: T,
   method: U,
   args: Parameters<T["functions"][U]>,
-  domain: string = ""
+  tag: string = ""
 ): TransactionMethods<ContractMethodReturnType<T, U>> => {
   const lastArg = args[args.length - 1];
 
@@ -77,8 +77,7 @@ export const getTransactionMethods = <
     const populatedTransaction = await contract.populateTransaction[
       method as string
     ](...[...args, mergedOverrides]);
-    populatedTransaction.data =
-      populatedTransaction.data + domain.replace(/^(0x)/, "");
+    populatedTransaction.data = populatedTransaction.data + tag;
     return populatedTransaction;
   };
 

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -61,7 +61,7 @@ export const getTransactionMethods = <
   contract: T,
   method: U,
   args: Parameters<T["functions"][U]>,
-  suffix: string = ""
+  domain: string = ""
 ): TransactionMethods<ContractMethodReturnType<T, U>> => {
   const lastArg = args[args.length - 1];
 
@@ -77,7 +77,8 @@ export const getTransactionMethods = <
     const populatedTransaction = await contract.populateTransaction[
       method as string
     ](...[...args, mergedOverrides]);
-    populatedTransaction.data = populatedTransaction.data + suffix;
+    populatedTransaction.data =
+      populatedTransaction.data + domain.replace(/^(0x)/, "");
     return populatedTransaction;
   };
 


### PR DESCRIPTION
## Motivation
Provide an on-chain method for attributing fulfillment of a given Seaport order to a specific domain

## Solution
Allow developers to pass in an optional string `domain`, hash the domain in `fulfill.ts` to create a `tag`, and append the tag to the end of calldata for `fulfillment`, `validate`, and `cancel` transaction calls

## Additional Context
- Fulfillment methods in `seaport.ts` and `fulfill.ts` now accept an optional string `domain` param
- If a domain is passed in, it is hashed via `getTagFromDomain` and the tag is passed into the call to `getTransactionMethods`
- If no domain is passed in, `getTagFromDomain` is not called and the tag passed into `getTransactionMethods` defaults to an empty string
- Updated tests to verify:
      1.  No tag is created when domain is left empty
      2. `getTagFromDomain` works with various domains
      3. Tag is appended to end of fulfillment calldata

## Open Questions
1. Should tag creation be handled in `seaport.ts` and `fulfill.ts` or in `getTransactionMethods` itself in `usecase.ts`?
2. Please ensure the optional param handling looks as expected (domain needs to be passed from fulfillment methods in `seaport.ts`, to fulfillment methods in `fulfill.ts`, to calls to `getTransactionMethods` in `usecase.ts`. 
3. Sanity check on [regex](https://github.com/ProjectOpenSea/seaport-js/blob/stephan/attributions-calldata/src/utils/fulfill.ts#L853) for handling "0x" prefix

## TODO
1. Write domain registry contract and add helper util function to SDK for registering domain/warning user if their domain isn't registered
2. Update Seaport README