### PR TITLE
Strip unnecessary async functions and replace with normal functions

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -178,7 +178,7 @@ const offerAndConsiderationFulfillmentMapping: {
   },
 } as const;
 
-export async function fulfillBasicOrder({
+export function fulfillBasicOrder({
   order,
   seaportContract,
   offererBalancesAndApprovals,
@@ -202,12 +202,8 @@ export async function fulfillBasicOrder({
   tips?: ConsiderationItem[];
   conduitKey: string;
   domain?: string;
-}): Promise<
-  OrderUseCase<
-    ExchangeAction<
-      ContractMethodReturnType<SeaportContract, "fulfillBasicOrder">
-    >
-  >
+}): OrderUseCase<
+  ExchangeAction<ContractMethodReturnType<SeaportContract, "fulfillBasicOrder">>
 > {
   const { offer, consideration } = order.parameters;
   const considerationIncludingTips = [...consideration, ...tips];
@@ -284,10 +280,7 @@ export async function fulfillBasicOrder({
 
   const payableOverrides = { value: totalNativeAmount };
 
-  const approvalActions = await getApprovalActions(
-    insufficientApprovals,
-    signer
-  );
+  const approvalActions = getApprovalActions(insufficientApprovals, signer);
 
   const exchangeAction = {
     type: "exchange",
@@ -308,7 +301,7 @@ export async function fulfillBasicOrder({
   };
 }
 
-export async function fulfillStandardOrder({
+export function fulfillStandardOrder({
   order,
   unitsToFill = 0,
   totalSize,
@@ -346,13 +339,11 @@ export async function fulfillStandardOrder({
   timeBasedItemParams: TimeBasedItemParams;
   signer: Signer;
   domain?: string;
-}): Promise<
-  OrderUseCase<
-    ExchangeAction<
-      ContractMethodReturnType<
-        SeaportContract,
-        "fulfillAdvancedOrder" | "fulfillOrder"
-      >
+}): OrderUseCase<
+  ExchangeAction<
+    ContractMethodReturnType<
+      SeaportContract,
+      "fulfillAdvancedOrder" | "fulfillOrder"
     >
   >
 > {
@@ -419,10 +410,7 @@ export async function fulfillStandardOrder({
 
   const payableOverrides = { value: totalNativeAmount };
 
-  const approvalActions = await getApprovalActions(
-    insufficientApprovals,
-    signer
-  );
+  const approvalActions = getApprovalActions(insufficientApprovals, signer);
 
   const isGift = recipientAddress !== ethers.constants.AddressZero;
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

These three low-level functions are unnecessary async functions:

- `fulfillBasicOrder` in `src/utils/fulfill.ts`
- `fulfillStandardOrder` in `src/utils/fulfill.ts`
- `getApprovalActions` in `src/utils/approval.ts`

## Solution

This PR converts them to normal functions by stripping off the `async`-keyword.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
