### PR TITLE
Support custom criteria in createOrder

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -119,7 +119,18 @@ export type Erc721ItemWithCriteria = {
   endAmount?: string;
 };
 
-type Erc721Item = BasicErc721Item | Erc721ItemWithCriteria;
+export type Erc721ItemWithMerkleRoot = {
+  itemType: ItemType.ERC721;
+  token: string;
+  criteria: string;
+  amount?: string;
+  endAmount?: string;
+};
+
+type Erc721Item =
+  | BasicErc721Item
+  | Erc721ItemWithCriteria
+  | Erc721ItemWithMerkleRoot;
 
 export type BasicErc1155Item = {
   itemType: ItemType.ERC1155;
@@ -137,7 +148,18 @@ export type Erc1155ItemWithCriteria = {
   endAmount?: string;
 };
 
-type Erc1155Item = BasicErc1155Item | Erc1155ItemWithCriteria;
+export type Erc1155ItemWithMerkleRoot = {
+  itemType: ItemType.ERC1155;
+  token: string;
+  criteria: string;
+  amount: string;
+  endAmount?: string;
+};
+
+type Erc1155Item =
+  | BasicErc1155Item
+  | Erc1155ItemWithCriteria
+  | Erc1155ItemWithMerkleRoot;
 
 export type CurrencyItem = {
   token?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,24 +113,12 @@ export type BasicErc721Item = {
 export type Erc721ItemWithCriteria = {
   itemType: ItemType.ERC721;
   token: string;
-  identifiers: string[];
+  amount?: string;
+  endAmount?: string;
   // Used for criteria based items i.e. offering to buy 5 NFTs for a collection
-  amount?: string;
-  endAmount?: string;
-};
+} & ({ identifiers: string[] } | { criteria: string });
 
-export type Erc721ItemWithMerkleRoot = {
-  itemType: ItemType.ERC721;
-  token: string;
-  criteria: string;
-  amount?: string;
-  endAmount?: string;
-};
-
-type Erc721Item =
-  | BasicErc721Item
-  | Erc721ItemWithCriteria
-  | Erc721ItemWithMerkleRoot;
+type Erc721Item = BasicErc721Item | Erc721ItemWithCriteria;
 
 export type BasicErc1155Item = {
   itemType: ItemType.ERC1155;
@@ -143,23 +131,11 @@ export type BasicErc1155Item = {
 export type Erc1155ItemWithCriteria = {
   itemType: ItemType.ERC1155;
   token: string;
-  identifiers: string[];
   amount: string;
   endAmount?: string;
-};
+} & ({ identifiers: string[] } | { criteria: string });
 
-export type Erc1155ItemWithMerkleRoot = {
-  itemType: ItemType.ERC1155;
-  token: string;
-  criteria: string;
-  amount: string;
-  endAmount?: string;
-};
-
-type Erc1155Item =
-  | BasicErc1155Item
-  | Erc1155ItemWithCriteria
-  | Erc1155ItemWithMerkleRoot;
+type Erc1155Item = BasicErc1155Item | Erc1155ItemWithCriteria;
 
 export type CurrencyItem = {
   token?: string;

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -72,8 +72,11 @@ export const mapInputItemToOfferItem = (item: CreateInputItem): OfferItem => {
   // Item is an NFT
   if ("itemType" in item) {
     // Convert this to a criteria based item
-    if ("identifiers" in item) {
-      const tree = new MerkleTree(item.identifiers);
+    if ("identifiers" in item || "criteria" in item) {
+      const root =
+        "criteria" in item
+          ? item.criteria
+          : new MerkleTree(item.identifiers).getRoot();
 
       return {
         itemType:
@@ -81,7 +84,7 @@ export const mapInputItemToOfferItem = (item: CreateInputItem): OfferItem => {
             ? ItemType.ERC721_WITH_CRITERIA
             : ItemType.ERC1155_WITH_CRITERIA,
         token: item.token,
-        identifierOrCriteria: tree.getRoot(),
+        identifierOrCriteria: root,
         startAmount: item.amount ?? "1",
         endAmount: item.endAmount ?? item.amount ?? "1",
       };


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
Seaport-js supports creating orders for NFTs using either a single token or a list of token ids. While this is convenient and saves us from messing with merkle trees ourselves, e.g. collection-wide offers for several 100k NFTs become problematic to execute and crippling user experience, since we're creating and processing an endless list of ids on the client side.
For this particular use case, you may want to compute a merkle root on the server side to spare the browser the work.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
this change enables passing in a pre-computed merkle root into the `createOrder` call for ERC721 and ERC1155, using a new `criteria` param (as opposed to using `identifier` or `identifiers`)