### PR TITLE
Fix bulk fulfill criteria order

### DIFF
--- a/src/utils/criteria.ts
+++ b/src/utils/criteria.ts
@@ -45,10 +45,9 @@ export const generateCriteriaResolvers = ({
       | typeof considerationCriteriaItems,
     criterias: InputCriteria[][]
   ) =>
-    criteriaItems.map(({ orderIndex, item, index, side }, i) => {
+    criteriaItems.map(({ orderIndex, item, index, side }) => {
       const merkleRoot = item.identifierOrCriteria || "0";
-      const inputCriteria: InputCriteria = criterias[orderIndex][i];
-
+      const inputCriteria: InputCriteria = criterias[orderIndex][index];
       return {
         orderIndex,
         index,

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -590,7 +590,15 @@ export async function fulfillAvailableOrders({
 
   let totalNativeAmount = BigNumber.from(0);
   const totalInsufficientApprovals: InsufficientApprovals = [];
-  const hasCriteriaItems = false;
+  const criteriaOffersAndConsiderations = sanitizedOrdersMetadata
+    .flatMap((orderMetadata) => [
+      orderMetadata.order.parameters.offer,
+      orderMetadata.order.parameters.consideration,
+    ])
+    .flat()
+    .filter(({ itemType }) => isCriteriaItem(itemType));
+
+  const hasCriteriaItems = criteriaOffersAndConsiderations.length > 0;
 
   const addApprovalIfNeeded = (
     orderInsufficientApprovals: InsufficientApprovals


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

I would like to fulfill collection based offers in bulk via `fulfillOrders`, but currently the `considerationCriteria` that I specify get ignored due to this line: https://github.com/ProjectOpenSea/seaport-js/blob/main/src/utils/fulfill.ts#L593

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

- Compute `hasCriteriaItems` according to the offers/considerations
- Add a test to verify behavior

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
