### PR TITLE
Support custom criteria in createOrder [rebased]

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -116,11 +116,10 @@ export type BasicErc721Item = {
 export type Erc721ItemWithCriteria = {
   itemType: ItemType.ERC721;
   token: string;
-  identifiers: string[];
-  // Used for criteria based items i.e. offering to buy 5 NFTs for a collection
   amount?: string;
   endAmount?: string;
-};
+  // Used for criteria based items i.e. offering to buy 5 NFTs for a collection
+} & ({ identifiers: string[] } | { criteria: string });
 
 type Erc721Item = BasicErc721Item | Erc721ItemWithCriteria;
 
@@ -135,10 +134,9 @@ export type BasicErc1155Item = {
 export type Erc1155ItemWithCriteria = {
   itemType: ItemType.ERC1155;
   token: string;
-  identifiers: string[];
   amount: string;
   endAmount?: string;
-};
+} & ({ identifiers: string[] } | { criteria: string });
 
 type Erc1155Item = BasicErc1155Item | Erc1155ItemWithCriteria;
 

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -72,8 +72,11 @@ export const mapInputItemToOfferItem = (item: CreateInputItem): OfferItem => {
   // Item is an NFT
   if ("itemType" in item) {
     // Convert this to a criteria based item
-    if ("identifiers" in item) {
-      const tree = new MerkleTree(item.identifiers);
+    if ("identifiers" in item || "criteria" in item) {
+      const root =
+        "criteria" in item
+          ? item.criteria
+          : new MerkleTree(item.identifiers).getRoot();
 
       return {
         itemType:
@@ -81,7 +84,7 @@ export const mapInputItemToOfferItem = (item: CreateInputItem): OfferItem => {
             ? ItemType.ERC721_WITH_CRITERIA
             : ItemType.ERC1155_WITH_CRITERIA,
         token: item.token,
-        identifierOrCriteria: tree.getRoot(),
+        identifierOrCriteria: root,
         startAmount: item.amount ?? "1",
         endAmount: item.endAmount ?? item.amount ?? "1",
       };


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
Seaport-js supports creating orders for NFTs using either a single token or a list of token ids. While this is convenient and saves us from messing with merkle trees ourselves, e.g. collection-wide offers for several 100k NFTs become problematic to execute and crippling user experience, since we're creating and processing an endless list of ids on the client side.
For this particular use case, you may want to compute a merkle root on the server side to spare the browser the work.

This PR was rebased on Seaport 1.1.0 and supersedes #147  

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
this change enables passing in a pre-computed merkle root to the `createOrder` call for ERC721 and ERC1155, using a new `criteria` param (as opposed to using `identifier` or `identifiers`)