### PR TITLE
Prevent rounding issue with partial fills

### DIFF
--- a/src/__tests__/utils/balance.ts
+++ b/src/__tests__/utils/balance.ts
@@ -108,7 +108,6 @@ export const verifyBalancesAfterFulfill = async ({
   const orderWithAdjustedFills = unitsToFill
     ? mapOrderAmountsFromUnitsToFill(order, {
         unitsToFill,
-        totalFilled,
         totalSize,
       })
     : mapOrderAmountsFromFilledStatus(order, {

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -368,7 +368,6 @@ export async function fulfillStandardOrder(
   const orderWithAdjustedFills = unitsToFill
     ? mapOrderAmountsFromUnitsToFill(order, {
         unitsToFill,
-        totalFilled,
         totalSize,
       })
     : // Else, we adjust the order by the remaining order left to be fulfilled
@@ -577,7 +576,6 @@ export async function fulfillAvailableOrders({
       order: orderMetadata.unitsToFill
         ? mapOrderAmountsFromUnitsToFill(orderMetadata.order, {
             unitsToFill: orderMetadata.unitsToFill,
-            totalFilled: orderMetadata.orderStatus.totalFilled,
             totalSize: orderMetadata.orderStatus.totalSize,
           })
         : // Else, we adjust the order by the remaining order left to be fulfilled


### PR DESCRIPTION
## Motivation

A rounding error is plaguing partial fulfilment with seaport-js, as discussed in e.g. #132 and #141 , and demonstrated via #145 and #190 . In #185 , user @tercel proposed a solution, which @wooglie turned into a proof of concept [here](https://github.com/wooglie/seaport-js/pull/1/files), that seems to tick all the boxes.


## Solution

I've ported @tercel 's solution to a clean slate of 1.1.0, together with some slight changes to @0xMasayoshi 's unit tests from #145. I did some testing with various values (different prices and precisions, and fee-basisPoints) and it seems to work fine now, yet there are some limitations to the proposed solution.

## Limitations
There's a lot of back and forth going on in the discussions, read this carefully to understand the limitations to handle the use case properly.

_TL/DR: create your orders by multiplying the number of nfts with the price per nft, don't set an arbitrary price for the whole bundle if you want to do partial fills. if your orders uses seaport-js's **fees** implementation, the price per nft shouldn't have more than 12 decimals (for currencies with 18 decimals)_ 

In detail:
- "10 ETH / 3 NFT doesn't work" - well yeah, even with floating points you'd end up with an infinitely small amount of inaccuracy (3.33333333...), and this fix won't solve that particular case. you have to *create* your order by multiplying the **amount of NFTs** with the target **sale price per NFT** already. so instead of saying "i want 10 ETH for 3 NFTs", you have to approach it as "i want 3.333 ETH for each NFT, for up to 3 units", if you want partial fills - and this circumvents the problem altogether by having clear divisibility (see [here](https://github.com/ProjectOpenSea/seaport-js/pull/197/files#diff-dca5b1ad9aeafdacac4c558083e92ba71349fa114df87ae7633f993c2199af9fR171-R176) for reference).
- when we're applying fees, things can get a bit murky still. we can again run into a situation where the resulting fees are not divisible by the number of units, because the basis points may be something arbitrary set by the user and out of our control. this fix solves the issue to an extent, but you'd have to limit the number of decimals of your sale price. Using e.g. ETH (18 decimals), your price can have up to 12 decimals to allow for enough "room" for the calculation to be safe. it _may_ work if with a higher number of decimals too for some nice round values, but you might be starting to run into edge cases when e.g. someone sets their NFT royalty to an odd number like 2.43% (see [here](https://github.com/ProjectOpenSea/seaport-js/pull/197/files#diff-dca5b1ad9aeafdacac4c558083e92ba71349fa114df87ae7633f993c2199af9fR153-R179) for reference).
  - OPEN: how are currencies with less decimals affected? e.g. USDC has 6 only decimals, how precise can we get --> to verify