### PR TITLE
throw an error when fulfilling orders without signatures

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -808,6 +808,10 @@ export class Seaport {
       >
     >
   > {
+    if (!order.signature) {
+      throw new Error("Order is missing signature");
+    }
+
     const { parameters: orderParameters } = order;
     const { offerer, offer, consideration } = orderParameters;
 
@@ -959,6 +963,12 @@ export class Seaport {
     domain?: string;
     exactApproval?: boolean;
   }) {
+    if (
+      fulfillOrderDetails.some((orderDetails) => !orderDetails.order.signature)
+    ) {
+      throw new Error("All orders must include signatures");
+    }
+
     const fulfiller = this._getSigner(accountAddress);
 
     const fulfillerAddress = await fulfiller.getAddress();

--- a/test/basic-fulfill.spec.ts
+++ b/test/basic-fulfill.spec.ts
@@ -84,6 +84,12 @@ describeWithFixture(
                 multicallProvider
               );
 
+            await expect(
+              seaport.fulfillOrder({
+                order: { ...order, signature: "" },
+              })
+            ).to.be.rejectedWith("Order is missing signature");
+
             const { actions } = await seaport.fulfillOrder({
               order,
               accountAddress: fulfiller.address,

--- a/test/fulfill-orders.spec.ts
+++ b/test/fulfill-orders.spec.ts
@@ -239,6 +239,14 @@ describeWithFixture(
 
             const thirdOrder = await thirdOrderUseCase.executeAllActions();
 
+            await expect(
+              seaport.fulfillOrders({
+                fulfillOrderDetails: [
+                  { order: { ...firstOrder, signature: "" } },
+                ],
+              })
+            ).to.be.rejectedWith("All orders must include signatures");
+
             const { actions } = await seaport.fulfillOrders({
               fulfillOrderDetails: [
                 { order: firstOrder },


### PR DESCRIPTION
opensea provides order signatures at a different endpoint so throw a helpful error if not provided