### PR TITLE
Update npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-npm:


### PR DESCRIPTION
Changes action hook from "created" to "published". In the github UI I usually create a draft first then publish it, but it doesn't get picked up that way so this should fix.