### PR TITLE
Make `Seaport.getOrderHash()` a static method

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -640,8 +640,20 @@ export class Seaport {
   /**
    * Calculates the order hash of order components so we can forgo executing a request to the contract
    * This saves us RPC calls and latency.
+   * @deprecated Please use the static `Seaport.getOrderHash()` method.
    */
-  public getOrderHash = (orderComponents: OrderComponents): string => {
+  public getOrderHash(orderComponents: OrderComponents): string {
+    console.warn(
+      "seaport.getOrderHash() is deprecated in favor of the static Seaport.getOrderHash()",
+    );
+    return Seaport.getOrderHash(orderComponents);
+  }
+
+  /**
+   * Calculates the order hash of order components so we can forgo executing a request to the contract
+   * This saves us RPC calls and latency.
+   */
+  public static getOrderHash(orderComponents: OrderComponents): string {
     const offerItemTypeString =
       "OfferItem(uint8 itemType,address token,uint256 identifierOrCriteria,uint256 startAmount,uint256 endAmount)";
     const considerationItemTypeString =
@@ -754,7 +766,7 @@ export class Seaport {
     );
 
     return derivedOrderHash;
-  };
+  }
 
   /**
    * Fulfills an order through either the basic method or the standard method
@@ -849,7 +861,7 @@ export class Seaport {
         operator: fulfillerOperator,
       }),
       this.multicallProvider.getBlock("latest"),
-      this.getOrderStatus(this.getOrderHash(orderParameters)),
+      this.getOrderStatus(Seaport.getOrderHash(orderParameters)),
     ]);
 
     const currentBlockTimestamp = currentBlock.timestamp;
@@ -1025,7 +1037,7 @@ export class Seaport {
       this.multicallProvider.getBlock("latest"),
       Promise.all(
         fulfillOrderDetails.map(({ order }) =>
-          this.getOrderStatus(this.getOrderHash(order.parameters)),
+          this.getOrderStatus(Seaport.getOrderHash(order.parameters)),
         ),
       ),
     ]);

--- a/test/cancel.spec.ts
+++ b/test/cancel.spec.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { parseEther } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 import { ItemType } from "../src/constants";
+import { Seaport } from "../src/seaport";
 import { CreateOrderInput } from "../src/types";
 import { describeWithFixture } from "./utils/setup";
 
@@ -95,7 +96,7 @@ describeWithFixture("As a user I want to cancel an order", (fixture) => {
     order.signature = "0x";
 
     await seaport.validate([order], offerer.address).transact();
-    const orderHash = seaport.getOrderHash(order.parameters);
+    const orderHash = Seaport.getOrderHash(order.parameters);
     expect(await seaport.getOrderStatus(orderHash)).to.have.property(
       "isValidated",
       true,

--- a/test/create-order.spec.ts
+++ b/test/create-order.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { parseEther } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 import { ItemType, MAX_INT, NO_CONDUIT, OrderType } from "../src/constants";
+import { Seaport } from "../src/seaport";
 import {
   ApprovalAction,
   CreateOrderAction,
@@ -740,8 +741,10 @@ describeWithFixture("As a user I want to create an order", (fixture) => {
     );
 
     const localOrderHash = seaport.getOrderHash(order.parameters);
+    const localOrderHashStatic = Seaport.getOrderHash(order.parameters);
 
     expect(contractOrderHash).eq(localOrderHash);
+    expect(contractOrderHash).eq(localOrderHashStatic);
   });
 
   it("should create an order with a salt including a hash of the supplied domain", async () => {
@@ -782,7 +785,7 @@ describeWithFixture("As a user I want to create an order", (fixture) => {
       order.parameters,
     );
 
-    const localOrderHash = seaport.getOrderHash(order.parameters);
+    const localOrderHash = Seaport.getOrderHash(order.parameters);
 
     expect(contractOrderHash).eq(localOrderHash);
     expect(order.parameters.salt.slice(0, 10)).eq(openseaMagicValue);
@@ -823,7 +826,7 @@ describeWithFixture("As a user I want to create an order", (fixture) => {
       order.parameters,
     );
 
-    const localOrderHash = seaport.getOrderHash(order.parameters);
+    const localOrderHash = Seaport.getOrderHash(order.parameters);
 
     expect(contractOrderHash).eq(localOrderHash);
     expect(order.parameters.salt.slice(0, 10)).eq("0x00000000");
@@ -866,7 +869,7 @@ describeWithFixture("As a user I want to create an order", (fixture) => {
       order.parameters,
     );
 
-    const localOrderHash = seaport.getOrderHash(order.parameters);
+    const localOrderHash = Seaport.getOrderHash(order.parameters);
 
     expect(contractOrderHash).eq(localOrderHash);
     expect(order.parameters.salt).eq(`0x${"0".repeat(60)}abcd`);
@@ -913,7 +916,7 @@ describeWithFixture("As a user I want to create an order", (fixture) => {
       order.parameters,
     );
 
-    const localOrderHash = seaport.getOrderHash(order.parameters);
+    const localOrderHash = Seaport.getOrderHash(order.parameters);
 
     expect(contractOrderHash).eq(localOrderHash);
     expect(order.parameters.zone).eq(zone);

--- a/test/criteria-based.spec.ts
+++ b/test/criteria-based.spec.ts
@@ -5,6 +5,7 @@ import { BigNumber } from "ethers";
 import { parseEther } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 import { ItemType, MAX_INT } from "../src/constants";
+import { Seaport } from "../src/seaport";
 import { CreateOrderInput, CurrencyItem, OrderWithCounter } from "../src/types";
 import * as fulfill from "../src/utils/fulfill";
 import { MerkleTree } from "../src/utils/merkletree";
@@ -149,7 +150,7 @@ describeWithFixture(
             const order = await executeAllActions();
 
             const orderStatus = await seaport.getOrderStatus(
-              seaport.getOrderHash(order.parameters),
+              Seaport.getOrderHash(order.parameters),
             );
 
             const ownerToTokenToIdentifierBalances =

--- a/test/partial-fulfill.spec.ts
+++ b/test/partial-fulfill.spec.ts
@@ -5,6 +5,7 @@ import { BigNumber } from "ethers";
 import { parseEther, parseUnits } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 import { ItemType, MAX_INT, OrderType } from "../src/constants";
+import { Seaport } from "../src/seaport";
 import { TestERC1155 } from "../src/typechain-types";
 import { CreateOrderInput, CurrencyItem } from "../src/types";
 import * as fulfill from "../src/utils/fulfill";
@@ -90,7 +91,7 @@ describeWithFixture(
           expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
 
           const orderStatus = await seaport.getOrderStatus(
-            seaport.getOrderHash(order.parameters),
+            Seaport.getOrderHash(order.parameters),
           );
 
           const ownerToTokenToIdentifierBalances =
@@ -249,7 +250,7 @@ describeWithFixture(
           expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
 
           const orderStatus = await seaport.getOrderStatus(
-            seaport.getOrderHash(order.parameters),
+            Seaport.getOrderHash(order.parameters),
           );
 
           const ownerToTokenToIdentifierBalances =
@@ -377,7 +378,7 @@ describeWithFixture(
           expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
 
           const orderStatus = await seaport.getOrderStatus(
-            seaport.getOrderHash(order.parameters),
+            Seaport.getOrderHash(order.parameters),
           );
 
           const ownerToTokenToIdentifierBalances =
@@ -501,7 +502,7 @@ describeWithFixture(
           expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
 
           const orderStatus = await seaport.getOrderStatus(
-            seaport.getOrderHash(order.parameters),
+            Seaport.getOrderHash(order.parameters),
           );
 
           const ownerToTokenToIdentifierBalances =
@@ -650,7 +651,7 @@ describeWithFixture(
           expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
 
           const orderStatus = await seaport.getOrderStatus(
-            seaport.getOrderHash(order.parameters),
+            Seaport.getOrderHash(order.parameters),
           );
 
           const ownerToTokenToIdentifierBalances =
@@ -746,7 +747,7 @@ describeWithFixture(
           expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
 
           const orderStatus = await seaport.getOrderStatus(
-            seaport.getOrderHash(order.parameters),
+            Seaport.getOrderHash(order.parameters),
           );
 
           const ownerToTokenToIdentifierBalances =
@@ -888,7 +889,7 @@ describeWithFixture(
           expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
 
           const orderStatus = await seaport.getOrderStatus(
-            seaport.getOrderHash(order.parameters),
+            Seaport.getOrderHash(order.parameters),
           );
 
           const ownerToTokenToIdentifierBalances =


### PR DESCRIPTION
Currently users need an instantiated `Seaport` to have access to `getOrderHash()` but there are use cases where one would want to get the `orderHash` outside of contexts where `Seaport` is instantiated. One such scenario would be storing orders in a database where modules could benefit from having static access to this method.

`getOrderHash()` doesn't utilize any instance internals so in changing this I've changed the method declaration to `public static getOrderHash()`. Since this would be a breaking change, I've re-added the instance method which now utilizes `Seaport.getOrderHash()` under the hood and issues a deprecation warning.

I've modified the `"should have the same order hash as on the contract"` test to check both the static and instance versions of `getOrderHash()`.
