### PR TITLE
Fix undefined error in tip parsing

### DIFF
--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -69,7 +69,6 @@ export const deductFees = <T extends Item>(
 };
 
 export const mapInputItemToOfferItem = (item: CreateInputItem): OfferItem => {
-  // Item is an NFT
   if ("itemType" in item) {
     // Convert this to a criteria based item
     if ("identifiers" in item || "criteria" in item) {
@@ -94,7 +93,8 @@ export const mapInputItemToOfferItem = (item: CreateInputItem): OfferItem => {
       return {
         itemType: item.itemType,
         token: item.token,
-        identifierOrCriteria: item.identifier,
+        // prevent undefined for fungible items
+        identifierOrCriteria: item.identifier || "0",
         // @ts-ignore
         startAmount: item.amount,
         // @ts-ignore

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -94,7 +94,7 @@ export const mapInputItemToOfferItem = (item: CreateInputItem): OfferItem => {
         itemType: item.itemType,
         token: item.token,
         // prevent undefined for fungible items
-        identifierOrCriteria: item.identifier || "0",
+        identifierOrCriteria: item.identifier ?? "0",
         // @ts-ignore
         startAmount: item.amount,
         // @ts-ignore


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

The `fulfillOrders` flow when using a tip will hit this function and fungible (NATIVE) tokens will be mapped to have missing `identifier` field causing errors downstream.

I removed the errornous comment and implemented the fix but due to limited capacity I didn't bother with tests :)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
