### PR TITLE
Add payableOverrides to the fulfillOrder method.

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -780,6 +780,7 @@ export class Seaport {
    *                               Defaults to the zero address which means the offer goes to the fulfiller
    * @param input.domain optional domain to be hashed and appended to calldata
    * @param input.exactApproval optional boolean to indicate whether the approval should be exact or not
+   * * @param input.overrides any overrides the client wants, will ignore value
    * @returns a use case containing the set of approval actions and fulfillment action
    */
   public async fulfillOrder({

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -794,6 +794,7 @@ export class Seaport {
     recipientAddress = ethers.constants.AddressZero,
     domain,
     exactApproval = false,
+    overrides,
   }: {
     order: OrderWithCounter;
     unitsToFill?: BigNumberish;
@@ -806,6 +807,7 @@ export class Seaport {
     recipientAddress?: string;
     domain?: string;
     exactApproval?: boolean;
+    overrides?: PayableOverrides;
   }): Promise<
     OrderUseCase<
       ExchangeAction<
@@ -903,6 +905,7 @@ export class Seaport {
           signer: fulfiller,
           tips: tipConsiderationItems,
           domain,
+          overrides,
         },
         exactApproval,
       );
@@ -931,6 +934,7 @@ export class Seaport {
         fulfillerOperator,
         recipientAddress,
         domain,
+        overrides,
       },
       exactApproval,
     );

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -780,7 +780,7 @@ export class Seaport {
    *                               Defaults to the zero address which means the offer goes to the fulfiller
    * @param input.domain optional domain to be hashed and appended to calldata
    * @param input.exactApproval optional boolean to indicate whether the approval should be exact or not
-   * * @param input.overrides any overrides the client wants, will ignore value
+   * @param input.overrides any overrides the client wants, will ignore value
    * @returns a use case containing the set of approval actions and fulfillment action
    */
   public async fulfillOrder({

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -3,6 +3,7 @@ import {
   BigNumberish,
   ContractTransaction,
   ethers,
+  PayableOverrides,
   Signer,
 } from "ethers";
 import type {
@@ -191,6 +192,7 @@ export function fulfillBasicOrder(
     tips = [],
     conduitKey = NO_CONDUIT,
     domain,
+    overrides,
   }: {
     order: Order;
     seaportContract: Seaport;
@@ -203,6 +205,7 @@ export function fulfillBasicOrder(
     tips?: ConsiderationItem[];
     conduitKey: string;
     domain?: string;
+    overrides?: PayableOverrides;
   },
   exactApproval: boolean,
 ): OrderUseCase<
@@ -281,7 +284,7 @@ export function fulfillBasicOrder(
     zoneHash: order.parameters.zoneHash,
   };
 
-  const payableOverrides = { value: totalNativeAmount };
+  const payableOverrides = { ...overrides, value: totalNativeAmount };
 
   const approvalActions = getApprovalActions(
     insufficientApprovals,
@@ -328,6 +331,7 @@ export function fulfillStandardOrder(
     recipientAddress,
     signer,
     domain,
+    overrides,
   }: {
     order: Order;
     unitsToFill?: BigNumberish;
@@ -347,6 +351,7 @@ export function fulfillStandardOrder(
     timeBasedItemParams: TimeBasedItemParams;
     signer: Signer;
     domain?: string;
+    overrides?: PayableOverrides;
   },
   exactApproval: boolean,
 ): OrderUseCase<
@@ -417,7 +422,7 @@ export function fulfillStandardOrder(
     fulfillerOperator,
   });
 
-  const payableOverrides = { value: totalNativeAmount };
+  const payableOverrides = { ...overrides, value: totalNativeAmount };
 
   const approvalActions = getApprovalActions(
     insufficientApprovals,

--- a/test/basic-fulfill.spec.ts
+++ b/test/basic-fulfill.spec.ts
@@ -28,6 +28,7 @@ describeWithFixture(
     const nftId = "1";
     const erc1155Amount = "3";
     const OPENSEA_DOMAIN = "opensea.io";
+    const overrideGasLimit = 10_000_000;
 
     beforeEach(async () => {
       fulfillBasicOrderSpy = sinon.spy(fulfill, "fulfillBasicOrder");
@@ -206,6 +207,7 @@ describeWithFixture(
               order,
               accountAddress: fulfiller.address,
               domain: OPENSEA_DOMAIN,
+              overrides: { gasLimit: overrideGasLimit },
             });
 
             const approvalAction = actions[0];
@@ -248,6 +250,7 @@ describeWithFixture(
               fulfillReceipt: receipt,
             });
             expect(fulfillBasicOrderSpy).calledOnce;
+            expect(transaction.gasLimit).equal(overrideGasLimit);
           });
 
           it("ERC721 <=> ERC20 (already validated order)", async () => {


### PR DESCRIPTION
Adds an optional `overrides` parameter to `fulfillOrder`. Has the same functionality as `overrides` in `matchOrders` except it will ignore `value` if provided as that is calculated elsewhere and based on the order.

## Motivation

I wanted to be able to set my own gasLimit in fulfillOrder and saw someone else had previously made an issue but never finished so I thought I would go ahead.

https://github.com/ProjectOpenSea/seaport-js/issues/82


## Solution

``` js
const { actions } = await seaport.fulfillOrder({
  order,
  accountAddress: fulfiller.address,
  domain: OPENSEA_DOMAIN,
  overrides: { gasLimit: overrideGasLimit }, // new feature
});
```
