### PR TITLE
Adjust Tips Correctly for Partial Fills

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -44,6 +44,7 @@ import {
   areAllCurrenciesSame,
   mapOrderAmountsFromFilledStatus,
   mapOrderAmountsFromUnitsToFill,
+  adjustTipsForPartialFills,
   totalItemsAmount,
 } from "./order";
 import {
@@ -377,11 +378,17 @@ export function fulfillStandardOrder(
         totalSize,
       });
 
+  let adjustedTips: ConsiderationItem[] = [];
+
+  if (tips.length > 0) {
+    adjustedTips = adjustTipsForPartialFills(tips, unitsToFill, totalSize);
+  }
+
   const {
     parameters: { offer, consideration },
   } = orderWithAdjustedFills;
 
-  const considerationIncludingTips = [...consideration, ...tips];
+  const considerationIncludingTips = [...consideration, ...adjustedTips];
 
   const offerCriteriaItems = offer.filter(({ itemType }) =>
     isCriteriaItem(itemType),

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -273,6 +273,32 @@ export const mapOrderAmountsFromUnitsToFill = (
   };
 };
 
+export function adjustTipsForPartialFills(
+  tips: ConsiderationItem[],
+  unitsToFill: BigNumberish,
+  totalSize: bigint,
+): ConsiderationItem[] {
+  const unitsToFillBn = BigInt(unitsToFill);
+
+  if (unitsToFillBn <= 0n) {
+    throw new Error("Units to fill must be greater than 0");
+  }
+
+  return tips.map((tip) => ({
+    ...tip,
+    startAmount: multiplyDivision(
+      tip.startAmount,
+      unitsToFillBn,
+      totalSize,
+    ).toString(),
+    endAmount: multiplyDivision(
+      tip.endAmount,
+      unitsToFillBn,
+      totalSize,
+    ).toString(),
+  }));
+}
+
 export const generateRandomSalt = (domain?: string) => {
   if (domain) {
     return toBeHex(

--- a/test/partial-fulfill.spec.ts
+++ b/test/partial-fulfill.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Signer, formatEther, parseEther, parseUnits } from "ethers";
+import { Signer, parseEther, parseUnits, Interface } from "ethers";
 import { ethers } from "hardhat";
 import { ItemType, MAX_INT, OrderType } from "../src/constants";
 import { TestERC1155 } from "../src/typechain-types";
@@ -12,6 +12,7 @@ import {
 import { describeWithFixture } from "./utils/setup";
 import { OPENSEA_DOMAIN, OPENSEA_DOMAIN_TAG } from "./utils/constants";
 import { SinonSpy } from "sinon";
+import { SeaportABIv15 } from "../src/abi/Seaport_v1_5";
 
 const sinon = require("sinon");
 
@@ -189,8 +190,7 @@ describeWithFixture(
 
           // This test verifies that the tips are adjusted correctly in the transaction.
           // The expected total is 2 ETH for tokens and 0.2 ETH for tips, totaling 2.2 ETH.
-          if (value)
-            expect(value.toString()).to.eq(parseEther("2.2").toString());
+          expect(value?.toString()).to.eq(parseEther("2.2").toString());
 
           const transaction = await action.transactionMethods.transact();
           expect(transaction.data.slice(-8)).to.eq(OPENSEA_DOMAIN_TAG);
@@ -295,7 +295,7 @@ describeWithFixture(
 
           // This test verifies that the tips are adjusted correctly in the transaction when denominations are very low.
           // The expected total is 5 wei for tokens and 1 wei for tips, totaling 6 wei.
-          if (value) expect(value.toString()).to.eq("6");
+          expect(value?.toString()).to.eq("6");
 
           const transaction = await action.transactionMethods.transact();
           expect(transaction.data.slice(-8)).to.eq(OPENSEA_DOMAIN_TAG);
@@ -507,6 +507,142 @@ describeWithFixture(
           expect(fulfillStandardOrderSpy.calledOnce);
         });
 
+        it("ERC1155 <=> ERC20 include tips correctly", async () => {
+          const { seaport, testErc20, testErc1155 } = fixture;
+
+          // Note: For simplicity in this test, tips are returned to the fulfiller.
+          const tips = [
+            {
+              amount: parseEther("1").toString(),
+              recipient: await fulfiller.getAddress(),
+              token: await testErc20.getAddress(),
+            },
+          ];
+
+          // Use ERC20 instead of eth
+          const token = await testErc20.getAddress();
+          standardCreateOrderInput = {
+            ...standardCreateOrderInput,
+            consideration: standardCreateOrderInput.consideration.map(
+              (item) => ({
+                ...item,
+                token,
+              }),
+            ),
+          };
+
+          await testErc20.mint(
+            await fulfiller.getAddress(),
+            (standardCreateOrderInput.consideration[0] as CurrencyItem).amount,
+          );
+
+          const { executeAllActions } = await seaport.createOrder(
+            standardCreateOrderInput,
+          );
+
+          const order = await executeAllActions();
+
+          expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
+
+          const orderStatus = await seaport.getOrderStatus(
+            seaport.getOrderHash(order.parameters),
+          );
+
+          const ownerToTokenToIdentifierBalances =
+            await getBalancesForFulfillOrder(
+              order,
+              await fulfiller.getAddress(),
+            );
+
+          const { actions } = await seaport.fulfillOrder({
+            order,
+            unitsToFill: 2,
+            accountAddress: await fulfiller.getAddress(),
+            domain: OPENSEA_DOMAIN,
+            tips,
+          });
+
+          expect(actions.length).to.eq(2);
+
+          const approvalAction = actions[0];
+
+          expect(approvalAction).to.deep.equal({
+            type: "approval",
+            token: await testErc20.getAddress(),
+            identifierOrCriteria: "0",
+            itemType: ItemType.ERC20,
+            transactionMethods: approvalAction.transactionMethods,
+            operator: await seaport.contract.getAddress(),
+          });
+
+          await approvalAction.transactionMethods.transact();
+
+          expect(
+            await testErc20.allowance(
+              await fulfiller.getAddress(),
+              await seaport.contract.getAddress(),
+            ),
+          ).to.eq(MAX_INT);
+
+          const fulfillAction = actions[1];
+
+          expect(fulfillAction).to.be.deep.equal({
+            type: "exchange",
+            transactionMethods: fulfillAction.transactionMethods,
+          });
+
+          const { data } =
+            await fulfillAction.transactionMethods.buildTransaction();
+
+          const iface = new Interface(SeaportABIv15);
+          const decoded = iface.parseTransaction({ data });
+          const considerations = decoded?.args[0][0][3];
+          expect(considerations.length).to.eq(3);
+
+          const tipConsideration = considerations.find(
+            (consideration: {
+              recipient: string;
+              token: string;
+              startAmount: BigInt;
+            }) =>
+              consideration.recipient === tips[0].recipient &&
+              consideration.token === tips[0].token &&
+              consideration.startAmount === BigInt(tips[0].amount),
+          );
+          // This test verifies that the tip consideration exists.
+          // Tip considerations will be adjusted correctly by the seaport protocol.
+          expect(tipConsideration).to.exist;
+
+          const transaction = await fulfillAction.transactionMethods.transact();
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_DOMAIN_TAG);
+
+          const receipt = await transaction.wait();
+
+          const offererErc1155Balance = await testErc1155.balanceOf(
+            await offerer.getAddress(),
+            nftId,
+          );
+
+          const fulfillerErc1155Balance = await testErc1155.balanceOf(
+            await fulfiller.getAddress(),
+            nftId,
+          );
+
+          expect(offererErc1155Balance).eq(8n);
+          expect(fulfillerErc1155Balance).eq(2n);
+
+          await verifyBalancesAfterFulfill({
+            ownerToTokenToIdentifierBalances,
+            order,
+            unitsToFill: 2,
+            orderStatus,
+            fulfillerAddress: await fulfiller.getAddress(),
+            fulfillReceipt: receipt!,
+          });
+
+          expect(fulfillStandardOrderSpy.calledOnce);
+        });
+
         it("ERC1155 <=> ERC20 (6 decimals) doesn't fail due to rounding error", async () => {
           const { seaport, testErc20USDC, testErc1155 } = fixture;
 
@@ -628,7 +764,6 @@ describeWithFixture(
             unitsToFill: 2,
             orderStatus,
             fulfillerAddress: await fulfiller.getAddress(),
-
             fulfillReceipt: receipt!,
           });
 


### PR DESCRIPTION
## Motivation

The Seaport SDK's tipping functionality does not correctly adjust tip amounts in scenarios involving partial fills of orders. This led to discrepancies in the expected vs. actual tip amounts being asked to the order fulfiller. I believe that the totalNativeAmount variable calculated by the getSummedTokenAndIdentifierAmounts function needs to receive an items array that has tips adjusted (taking into account unitsToFill and totalSize). Currently, in the context of a partial fill, the SDK correctly adjusts all considerations except for the tips when calculating the totalNativeAmount variable.

This issue could impact user experience where a fulfiller would overpay upfront and then be refunded by the seaport protocol. The need for accurate and predictable transaction handling motivated this fix. This PR aims to solve this issue by correctly adjusting tips based on the portion of the order that's filled.

## Scenario Description:

An NFT seller creates an order to sell 10 editions of a unique ERC1155 NFT, each priced at 1 ETH. To support a community initiative, they also include a tip as part of the transaction.

**Initial Order Setup:**

NFT Offer: 10 editions of a digital artwork (ERC1155 token).
Sale Price: 1 ETH per edition (total 10 ETH for all editions).
Tip: 1 ETH to a community wallet.

**Expected Behavior in Partial Fulfillment:**

A buyer decides to purchase 3 out of the 10 editions. The expected cost should be 3 ETH for the NFTs and a proportionally adjusted tip amount. Ideally, the tip should be adjusted to 0.3 ETH (since 3/10 of the total offer is being fulfilled).

**Bug Manifestation:**

Under the current SDK functionality, when the buyer completes this partial purchase, the total charged amount is not what they expect. The SDK incorrectly processes the tip without adjustment:
Actual Charge: 4 ETH (3 ETH for NFTs + 1 ETH unadjusted tip). 
Expected Charge: 3.3 ETH (3 ETH for NFTs + 0.3 ETH adjusted tip).

**Notes:** 
* Buyers initially get charged 4 ETH and the on-chain logic charges the right amount. the seaport protocols correctly adjust the tip but the seaport SDK doesn't: it sends the 0.3 ETH tip and refunds the 0.7 ETH to the transaction sender.
* I've tried to pass a tip amount that's already adjusted when calling ``seaport.fulfillOrder``. However, it doesn't work since the seaport protocol would adjust the adjusted tip when processing the transaction on-chain (resulting in an incorrect tip amount sent to the tip receiver).

## Solution

The solution involves creating and calling an `adjustTipsForPartialFills` function to accurately adjust tip amounts based on the filled portion of an order. The changes include:

1. Implementing logic within the `adjustTipsForPartialFills` function to correctly calculate the adjusted tip amounts.
2. Integrating this function within the order fulfillment process, specifically in the `fulfillStandardOrder` function, to apply these adjustments.

With these changes, the Seaport SDK would correctly calculate the totalNativeAmount value and correctly handle tip amounts in partial fill scenarios, ensuring accurate and reliable processing of these transactions.
