### PR TITLE
Remove incorrect Signer type

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -6,6 +6,7 @@ import {
   JsonRpcProvider,
   Provider,
   JsonRpcSigner,
+  Signer,
 } from "ethers";
 import {
   SEAPORT_CONTRACT_NAME,
@@ -33,7 +34,6 @@ import type {
   OrderWithCounter,
   TipInputItem,
   MatchOrdersFulfillment,
-  Signer,
   ApprovalAction,
   CreateBulkOrdersAction,
   SeaportContract,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, BytesLike, ContractTransaction, ethers } from "ethers";
+import { BigNumberish, ContractTransaction } from "ethers";
 import { ItemType, OrderType } from "./constants";
 import type { TestERC20, TestERC721 } from "./typechain-types";
 import { TransactionMethods } from "./utils/usecase";
@@ -25,28 +25,6 @@ export type SeaportConfig = {
     // A default conduit key to use when creating and fulfilling orders
     defaultConduitKey?: string;
   };
-};
-
-type TypedDataDomain = {
-  name?: string;
-  version?: string;
-  chainId?: BigNumberish;
-  verifyingContract?: string;
-  salt?: BytesLike;
-};
-
-type TypedDataField = {
-  name: string;
-  type: string;
-};
-
-// Temporary until TypedDataSigner is added in ethers (in v6)
-export type Signer = ethers.Signer & {
-  _signTypedData(
-    domain: TypedDataDomain,
-    types: Record<string, Array<TypedDataField>>,
-    value: Record<string, any>,
-  ): Promise<string>;
 };
 
 export type OfferItem = {


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

This pull request replaces the custom `Signer` type with the standard type from ethers. This update is due to changes in the ethers v6 library, specifically the deprecation and subsequent removal of the `_signTypedData` function. The existing custom `Signer` type, which extends `ethers.Signer` with `_signTypedData`, is now obsolete and incorrect.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Remove the custom type and related ones from `types.ts`.
- Update the `seaport.ts` import to use the standard `Signer` definition.