### PR TITLE
bugfix: Fix native currency tip amount scaling logic for partial fills when using fulfillOrders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a new marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -52,9 +52,8 @@ import {
   shouldUseBasicFulfill,
   validateAndSanitizeFromOrderStatus,
 } from "./utils/fulfill";
-import { getMaximumSizeForOrder, isCurrencyItem } from "./utils/item";
+import { isCurrencyItem } from "./utils/item";
 import {
-  adjustTipsForPartialFills,
   areAllCurrenciesSame,
   deductFees,
   feeToConsiderationItem,
@@ -1049,16 +1048,6 @@ export class Seaport {
           offererBalancesAndApprovals: offerersBalancesAndApprovals[index],
           offererOperator: allOffererOperators[index],
         };
-        if (order.tips.length > 0) {
-          order.tips = adjustTipsForPartialFills(
-            order.tips,
-            order.unitsToFill || 1,
-            // Max total amount to fulfill for scaling
-            getMaximumSizeForOrder({
-              ...order.order,
-            }),
-          );
-        }
 
         return order;
       },

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -574,6 +574,31 @@ export function fulfillAvailableOrders({
     ),
   }));
 
+  const adjustTips = (orderMetadata: {
+    order: Order;
+    unitsToFill?: BigNumberish;
+    orderStatus: OrderStatus;
+    offerCriteria: InputCriteria[];
+    considerationCriteria: InputCriteria[];
+    tips: ConsiderationItem[];
+    extraData: string;
+    offererBalancesAndApprovals: BalancesAndApprovals;
+    offererOperator: string;
+  }): ConsiderationItem[] => {
+    if (!orderMetadata.tips || !orderMetadata.tips.length) {
+      return [];
+    }
+
+    // Max total amount to fulfill for scaling
+    const maxUnits = getMaximumSizeForOrder(orderMetadata.order);
+
+    return adjustTipsForPartialFills(
+      orderMetadata.tips,
+      orderMetadata.unitsToFill || 1,
+      maxUnits,
+    );
+  };
+
   const ordersMetadataWithAdjustedFills = sanitizedOrdersMetadata.map(
     (orderMetadata) => ({
       ...orderMetadata,
@@ -589,6 +614,7 @@ export function fulfillAvailableOrders({
             totalFilled: orderMetadata.orderStatus.totalFilled,
             totalSize: orderMetadata.orderStatus.totalSize,
           }),
+      tips: adjustTips(orderMetadata),
     }),
   );
 

--- a/test/partial-fulfill.spec.ts
+++ b/test/partial-fulfill.spec.ts
@@ -24,6 +24,7 @@ describeWithFixture(
     let fulfiller: Signer;
 
     let fulfillStandardOrderSpy: SinonSpy;
+    let fulfillAvailableOrdersSpy: SinonSpy;
     let standardCreateOrderInput: CreateOrderInput;
     let secondTestErc1155: TestERC1155;
 
@@ -33,6 +34,7 @@ describeWithFixture(
       [offerer, zone, fulfiller] = await ethers.getSigners();
 
       fulfillStandardOrderSpy = sinon.spy(fulfill, "fulfillStandardOrder");
+      fulfillAvailableOrdersSpy = sinon.spy(fulfill, "fulfillAvailableOrders");
 
       const TestERC1155 = await ethers.getContractFactory("TestERC1155");
       secondTestErc1155 = await TestERC1155.deploy();
@@ -41,6 +43,7 @@ describeWithFixture(
 
     afterEach(() => {
       fulfillStandardOrderSpy.restore();
+      fulfillAvailableOrdersSpy.restore();
     });
 
     describe("An ERC1155 is partially transferred", () => {
@@ -304,7 +307,7 @@ describeWithFixture(
             fulfillReceipt: receipt!,
           });
 
-          expect(fulfillStandardOrderSpy.calledOnce);
+          expect(fulfillAvailableOrdersSpy.calledOnce).to.be.true;
         });
 
         it("ERC1155 <=> ETH adjust tips correctly with low denomination", async () => {

--- a/test/partial-fulfill.spec.ts
+++ b/test/partial-fulfill.spec.ts
@@ -14,6 +14,7 @@ import { OPENSEA_DOMAIN, OPENSEA_DOMAIN_TAG } from "./utils/constants";
 import { SinonSpy } from "sinon";
 import { SeaportABI } from "../src/abi/Seaport";
 import { FulfillOrdersMetadata } from "../lib/utils/fulfill";
+import { mapInputItemToOfferItem } from "../src/utils/order";
 
 const sinon = require("sinon");
 
@@ -307,11 +308,17 @@ describeWithFixture(
             fulfillReceipt: receipt!,
           });
 
+          const tipConsiderationItems = tips.map((tip) => ({
+            ...mapInputItemToOfferItem(tip),
+            recipient: tip.recipient,
+          }));
+
           const expectedArgs = {
             ordersMetadata: [
               {
                 order,
                 unitsToFill: 2,
+                tips: tipConsiderationItems,
               },
             ],
           };
@@ -323,19 +330,22 @@ describeWithFixture(
               }: {
                 ordersMetadata: FulfillOrdersMetadata;
               }) {
-                let match = true;
                 ordersMetadata.every((metadata, index) => {
-                  if (
-                    metadata.order !=
-                      expectedArgs.ordersMetadata[index].order ||
-                    metadata.unitsToFill !=
-                      expectedArgs.ordersMetadata[index].unitsToFill
-                  ) {
-                    match = false;
-                  }
+                  expect(metadata.order).to.deep.equal(
+                    expectedArgs.ordersMetadata[index].order,
+                    "order doesn't match expected value",
+                  );
+                  expect(metadata.unitsToFill).to.deep.equal(
+                    expectedArgs.ordersMetadata[index].unitsToFill,
+                    "unitsToFill doesn't match expected value",
+                  );
+                  expect(metadata.tips).to.deep.equal(
+                    expectedArgs.ordersMetadata[index].tips,
+                    "tips doesn't match expected value",
+                  );
                 });
-                return match;
-              }, "fulfillAvailableOrders arguments don't match expected values"),
+                return true;
+              }),
             ).calledOnce,
           ).to.be.true;
         });


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

Fixes [564](https://github.com/ProjectOpenSea/seaport-js/issues/564)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The tip amount scaling logic has been moved into the `fulfillAvailableOrders` function where all the order's offer and consideration items are scaled proportional to the ratio of the order being filled.

This ensures that the `fulfillAvailableOrders` function has access to the original (unscaled) tip amounts to be passed to the Seaport contract as consideration items.
