### PR TITLE
bugfix: handle undefined `unitsToFill` in fulfillOrders()

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -45,7 +45,8 @@ import {
   areAllCurrenciesSame,
   mapOrderAmountsFromFilledStatus,
   mapOrderAmountsFromUnitsToFill,
-  adjustTipsForPartialFills,
+  mapTipAmountsFromFilledStatus,
+  mapTipAmountsFromUnitsToFill,
   totalItemsAmount,
 } from "./order";
 import {
@@ -382,7 +383,7 @@ export function fulfillStandardOrder(
   let adjustedTips: ConsiderationItem[] = [];
 
   if (tips.length > 0) {
-    adjustedTips = adjustTipsForPartialFills(tips, unitsToFill, totalSize);
+    adjustedTips = mapTipAmountsFromUnitsToFill(tips, unitsToFill, totalSize);
   }
 
   const {
@@ -589,14 +590,17 @@ export function fulfillAvailableOrders({
       return [];
     }
 
-    // Max total amount to fulfill for scaling
-    const maxUnits = getMaximumSizeForOrder(orderMetadata.order);
-
-    return adjustTipsForPartialFills(
-      orderMetadata.tips,
-      orderMetadata.unitsToFill || 1,
-      maxUnits,
-    );
+    return orderMetadata.unitsToFill
+      ? mapTipAmountsFromUnitsToFill(
+          orderMetadata.tips,
+          orderMetadata.unitsToFill,
+          orderMetadata.orderStatus.totalSize,
+        )
+      : mapTipAmountsFromFilledStatus(
+          orderMetadata.tips,
+          orderMetadata.orderStatus.totalFilled,
+          orderMetadata.orderStatus.totalSize,
+        );
   };
 
   const ordersMetadataWithAdjustedFills = sanitizedOrdersMetadata.map(

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -185,7 +185,7 @@ export const mapOrderAmountsFromFilledStatus = (
 
   // i.e if totalFilled is 3 and totalSize is 4, there are 1 / 4 order amounts left to fill.
   const basisPoints =
-    totalSize - (totalFilled * ONE_HUNDRED_PERCENT_BP) / totalSize;
+    ((totalSize - totalFilled) * ONE_HUNDRED_PERCENT_BP) / totalSize;
 
   return {
     parameters: {
@@ -273,7 +273,7 @@ export const mapOrderAmountsFromUnitsToFill = (
   };
 };
 
-export function adjustTipsForPartialFills(
+export function mapTipAmountsFromUnitsToFill(
   tips: ConsiderationItem[],
   unitsToFill: BigNumberish,
   totalSize: bigint,
@@ -296,6 +296,26 @@ export function adjustTipsForPartialFills(
       unitsToFillBn,
       totalSize,
     ).toString(),
+  }));
+}
+
+export function mapTipAmountsFromFilledStatus(
+  tips: ConsiderationItem[],
+  totalFilled: bigint,
+  totalSize: bigint,
+): ConsiderationItem[] {
+  if (totalFilled === 0n || totalSize === 0n) {
+    return tips;
+  }
+
+  // i.e if totalFilled is 3 and totalSize is 4, there are 1 / 4 order amounts left to fill.
+  const basisPoints =
+    ((totalSize - totalFilled) * ONE_HUNDRED_PERCENT_BP) / totalSize;
+
+  return tips.map((tip) => ({
+    ...tip,
+    startAmount: multiplyBasisPoints(tip.startAmount, basisPoints).toString(),
+    endAmount: multiplyBasisPoints(tip.endAmount, basisPoints).toString(),
   }));
 }
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

Fixes #578 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR fixes the erroneous `basisPoints` calculation formula when handling the fulfilment of a partially filled orders using  `fulfillOrders()`. This caused the transaction to revert with an overflow error. As an extension to this fix, the tips scaling logic has also been updated to handle the scenario where `unitsToFill` is undefined.
