### PR TITLE
fix: add CJS marker to lib output for Node module resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # Seaport.js
 
-[Seaport][seaport-link] is a new marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.
+[Seaport][seaport-link] is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.
 
 - [Synopsis](#synopsis)
 - [Installation](#installation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a new marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "build": "hardhat build && tsc -p tsconfig.build.json",
+    "build": "hardhat build && tsc -p tsconfig.build.json && node scripts/postbuild.mjs",
     "check-types": "tsc --noEmit",
     "check-types:incremental": "npm run check-types --incremental",
     "coverage": "c8 npm run test",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensea/seaport-js",
   "version": "4.1.1",
-  "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a new marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
+  "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",
   "homepage": "https://github.com/ProjectOpenSea/seaport-js#readme",

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,0 +1,9 @@
+import { writeFileSync } from "node:fs";
+
+// The root package.json declares "type": "module" for Hardhat v3 compatibility,
+// but tsconfig.build.json compiles to CommonJS for backward compatibility with
+// CJS consumers. This marker tells Node to treat lib/*.js files as CommonJS.
+writeFileSync(
+  "lib/package.json",
+  JSON.stringify({ type: "commonjs" }, null, 2) + "\n",
+);


### PR DESCRIPTION
## Summary

- The Hardhat v3 migration (#857) added `"type": "module"` to `package.json`, but `tsconfig.build.json` still compiles to CommonJS. Node treats `lib/*.js` as ESM due to the root `"type"` field, breaking all CJS consumers (e.g. `@opensea/sdk`).
- Adds a `scripts/postbuild.mjs` that writes `lib/package.json` with `{"type":"commonjs"}` so Node correctly resolves the build output as CJS, while keeping the root ESM declaration for Hardhat v3.
- Bumps version to 4.1.1.

## Test plan

- [x] `npm run build` passes and `lib/package.json` is created with `{"type":"commonjs"}`
- [x] Verified `@opensea/sdk` tests pass with this fix applied (28/28 non-network test suites pass)
- [x] Verified the fix resolves the `exports is not defined in ES module scope` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)