### PR TITLE
Improve matchOrders and matchAdvancedOrders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -12,6 +12,7 @@ import {
   CROSS_CHAIN_SEAPORT_V1_6_ADDRESS,
   DOMAIN_REGISTRY_ADDRESS,
   EIP_712_ORDER_TYPE,
+  ItemType,
   KNOWN_CONDUIT_KEYS_TO_CONDUIT,
   MAX_INT,
   NO_CONDUIT,
@@ -1067,16 +1068,21 @@ export class Seaport {
   }
 
   /**
-   * NOTE: Largely incomplete. Does NOT do any balance or approval checks.
-   * Just exposes the bare bones matchOrders where clients will have to supply
-   * their own overrides as needed.
-   * @param input
-   * @param input.orders the list of orders to match
-   * @param input.fulfillments the list of fulfillments to match offer and considerations
-   * @param input.overrides any transaction overrides the client wants, will need to pass in value for matching orders with ETH.
-   * @param input.accountAddress Optional address for which to match the order with
-   * @param input.domain optional domain to be hashed and appended to calldata
-   * @returns set of transaction methods for matching orders
+   * Matches a set of orders against each other so that the total offer amounts
+   * satisfy the total consideration amounts across all matched fulfillments.
+   *
+   * WARNING: This is a low-level method that passes arguments directly to the Seaport
+   * contract. It does NOT perform balance or approval checks. Callers are responsible
+   * for ensuring all parties have sufficient balances and approvals before calling.
+   * Pass `value` in `overrides` when matching orders that include ETH.
+   *
+   * @param input.orders The list of orders to match.
+   * @param input.fulfillments The list of fulfillments pairing offer and consideration
+   *   components across the provided orders.
+   * @param input.overrides Transaction overrides (e.g. `{ value }` for ETH-based matches).
+   * @param input.accountAddress Optional address to send the transaction from.
+   * @param input.domain Optional domain to be hashed and appended to calldata.
+   * @returns A set of transaction methods (transact, estimateGas, staticCall, buildTransaction).
    */
   public matchOrders({
     orders,
@@ -1093,6 +1099,11 @@ export class Seaport {
   }): TransactionMethods<
     ContractMethodReturnType<SeaportContract, "matchOrders">
   > {
+    this._validateMatchOrdersNativeValue(
+      orders.map(o => o.parameters),
+      overrides,
+    )
+
     return getTransactionMethods(
       this._getSigner(accountAddress),
       this.contract,
@@ -1144,6 +1155,11 @@ export class Seaport {
   }): TransactionMethods<
     ContractMethodReturnType<SeaportContract, "matchAdvancedOrders">
   > {
+    this._validateMatchOrdersNativeValue(
+      orders.map(o => o.parameters),
+      overrides,
+    )
+
     return getTransactionMethods(
       this._getSigner(accountAddress),
       this.contract,
@@ -1212,6 +1228,32 @@ export class Seaport {
       )
 
       return await domainArray
+    }
+  }
+
+  /**
+   * Validates that `overrides.value` is provided when any of the matched orders
+   * involve native ETH. Forgetting to set `value` is a common mistake that
+   * results in an opaque revert from the Seaport contract.
+   */
+  private _validateMatchOrdersNativeValue(
+    orderParams: {
+      offer: { itemType: ItemType }[]
+      consideration: { itemType: ItemType }[]
+    }[],
+    overrides?: Overrides,
+  ) {
+    const hasNativeToken = orderParams.some(
+      params =>
+        params.offer.some(item => item.itemType === ItemType.NATIVE) ||
+        params.consideration.some(item => item.itemType === ItemType.NATIVE),
+    )
+
+    if (hasNativeToken && !overrides?.value) {
+      throw new Error(
+        "Orders contain native ETH items but no `value` was provided in overrides. " +
+          "Pass the required ETH amount via `overrides: { value }` to avoid a revert.",
+      )
     }
   }
 }

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -1103,18 +1103,27 @@ export class Seaport {
   }
 
   /**
-   * NOTE: Largely incomplete. Does NOT do any balance or approval checks.
-   * Just exposes the bare bones matchAdvancedOrders where clients will have to supply
-   * their own overrides as needed.
-   * @param input
-   * @param input.orders the list of advanced orders to match
-   * @param input.criteriaResolvers the list of criteria resolvers
-   * @param input.fulfillments the list of fulfillments to match offer and considerations
-   * @param input.recipient the recipient of any unspent offer item amounts or native tokens
-   * @param input.overrides any transaction overrides the client wants, will need to pass in value for matching orders with ETH.
-   * @param input.accountAddress Optional address for which to match the order with
-   * @param input.domain optional domain to be hashed and appended to calldata
-   * @returns set of transaction methods for matching advanced orders
+   * Matches a set of advanced orders against each other, supporting partial fills
+   * (numerator/denominator), criteria resolvers, extra data, and an explicit recipient
+   * for any unspent offer amounts or native tokens.
+   *
+   * WARNING: This is a low-level method that passes arguments directly to the Seaport
+   * contract. It does NOT perform balance or approval checks. Callers are responsible
+   * for ensuring all parties have sufficient balances and approvals before calling.
+   * Pass `value` in `overrides` when matching orders that include ETH.
+   *
+   * @param input.orders The list of advanced orders to match. Each order includes
+   *   numerator/denominator for partial fill amounts and extraData for zone validation.
+   * @param input.criteriaResolvers Resolvers for criteria-based items (e.g. collection offers),
+   *   mapping criteria to specific token identifiers with merkle proofs.
+   * @param input.fulfillments The list of fulfillments pairing offer and consideration
+   *   components across the provided orders.
+   * @param input.recipient The address to receive any unspent offer item amounts or
+   *   native tokens remaining after all fulfillments are applied.
+   * @param input.overrides Transaction overrides (e.g. `{ value }` for ETH-based matches).
+   * @param input.accountAddress Optional address to send the transaction from.
+   * @param input.domain Optional domain to be hashed and appended to calldata.
+   * @returns A set of transaction methods (transact, estimateGas, staticCall, buildTransaction).
    */
   public matchAdvancedOrders({
     orders,

--- a/test/match-advanced-orders.spec.ts
+++ b/test/match-advanced-orders.spec.ts
@@ -1,0 +1,385 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther, type Signer } from "ethers"
+import { ItemType, MAX_INT } from "../src/constants"
+import type {
+  AdvancedOrder,
+  CreateOrderInput,
+  CurrencyItem,
+  MatchOrdersFulfillment,
+  Order,
+} from "../src/types"
+import { getTransactionMethods } from "../src/utils/usecase"
+import {
+  getBalancesForFulfillOrder,
+  verifyBalancesAfterFulfill,
+} from "./utils/balance"
+import {
+  constructPrivateListingCounterOrder,
+  getPrivateListingFulfillments,
+} from "./utils/examples/privateListings"
+import { describeWithFixture } from "./utils/setup"
+
+const orderToAdvancedOrder = (order: Order): AdvancedOrder => ({
+  ...order,
+  numerator: 1n,
+  denominator: 1n,
+  extraData: "0x",
+})
+
+describeWithFixture("As a user I want to match an advanced order", fixture => {
+  let offerer: HardhatEthersSigner
+  let zone: HardhatEthersSigner
+  let privateListingRecipient: HardhatEthersSigner
+  let privateListingCreateOrderInput: CreateOrderInput
+  const nftId = "1"
+  const erc1155Amount = "3"
+  const erc1155ListingQuantity = "1"
+
+  beforeEach(async () => {
+    const { ethers } = fixture
+    ;[offerer, zone, privateListingRecipient] = await ethers.getSigners()
+  })
+
+  describe("A single ERC721 is to be transferred", () => {
+    describe("[Buy now] I want to buy a single ERC721 private listing", () => {
+      beforeEach(async () => {
+        const { testErc721 } = fixture
+
+        await testErc721.mint(await offerer.getAddress(), nftId)
+
+        privateListingCreateOrderInput = {
+          startTime: "0",
+          offer: [
+            {
+              itemType: ItemType.ERC721,
+              token: await testErc721.getAddress(),
+              identifier: nftId,
+            },
+          ],
+          consideration: [
+            {
+              amount: parseEther("10").toString(),
+              recipient: await offerer.getAddress(),
+            },
+            {
+              itemType: ItemType.ERC721,
+              token: await testErc721.getAddress(),
+              identifier: nftId,
+              recipient: await privateListingRecipient.getAddress(),
+            },
+          ],
+          // 2.5% fee
+          fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+        }
+      })
+
+      describe("with ETH", () => {
+        it("ERC721 <=> ETH", async () => {
+          const { seaport } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            await privateListingRecipient.getAddress(),
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+          const recipientAddress = await privateListingRecipient.getAddress()
+
+          const ownerToTokenToIdentifierBalances =
+            await getBalancesForFulfillOrder(
+              fixture.ethers.provider,
+              order,
+              recipientAddress,
+            )
+
+          const transaction = await seaport
+            .matchAdvancedOrders({
+              orders: [
+                orderToAdvancedOrder(order),
+                orderToAdvancedOrder(counterOrder),
+              ],
+              criteriaResolvers: [],
+              fulfillments,
+              recipient: recipientAddress,
+              overrides: {
+                value: counterOrder.parameters.offer[0].startAmount,
+              },
+              accountAddress: recipientAddress,
+            })
+            .transact()
+
+          const receipt = await transaction.wait()
+
+          await verifyBalancesAfterFulfill({
+            ownerToTokenToIdentifierBalances,
+            order,
+            fulfillerAddress: recipientAddress,
+            fulfillReceipt: receipt!,
+            provider: fixture.ethers.provider,
+          })
+        })
+      })
+
+      describe("with ERC20", () => {
+        beforeEach(async () => {
+          const { testErc20 } = fixture
+
+          // Use ERC20 instead of eth
+          privateListingCreateOrderInput = {
+            ...privateListingCreateOrderInput,
+            consideration: [
+              {
+                ...privateListingCreateOrderInput.consideration[0],
+                token: await testErc20.getAddress(),
+              },
+              ...privateListingCreateOrderInput.consideration.slice(1),
+            ],
+          }
+          await testErc20.mint(
+            await privateListingRecipient.getAddress(),
+            (privateListingCreateOrderInput.consideration[0] as CurrencyItem)
+              .amount,
+          )
+        })
+
+        it("ERC721 <=> ERC20", async () => {
+          const { seaport, testErc20 } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            await privateListingRecipient.getAddress(),
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+          const recipientAddress = await privateListingRecipient.getAddress()
+
+          const ownerToTokenToIdentifierBalances =
+            await getBalancesForFulfillOrder(
+              fixture.ethers.provider,
+              order,
+              recipientAddress,
+            )
+
+          await getTransactionMethods(
+            privateListingRecipient as unknown as Signer,
+            testErc20,
+            "approve",
+            [await seaport.contract.getAddress(), MAX_INT],
+          ).transact()
+          expect(
+            await testErc20.allowance(
+              recipientAddress,
+              await seaport.contract.getAddress(),
+            ),
+          ).to.eq(MAX_INT)
+
+          const transaction = await seaport
+            .matchAdvancedOrders({
+              orders: [
+                orderToAdvancedOrder(order),
+                orderToAdvancedOrder(counterOrder),
+              ],
+              criteriaResolvers: [],
+              fulfillments,
+              recipient: recipientAddress,
+              accountAddress: recipientAddress,
+            })
+            .transact()
+
+          const receipt = await transaction.wait()
+
+          await verifyBalancesAfterFulfill({
+            ownerToTokenToIdentifierBalances,
+            order,
+            fulfillerAddress: recipientAddress,
+            fulfillReceipt: receipt!,
+            provider: fixture.ethers.provider,
+          })
+        })
+      })
+    })
+  })
+
+  describe("A single ERC1155 is to be transferred", () => {
+    describe("[Buy now] I want to buy a single ERC1155 private listing", () => {
+      beforeEach(async () => {
+        const { testErc1155 } = fixture
+
+        await testErc1155.mint(await offerer.getAddress(), nftId, erc1155Amount)
+
+        privateListingCreateOrderInput = {
+          startTime: "0",
+          offer: [
+            {
+              itemType: ItemType.ERC1155,
+              token: await testErc1155.getAddress(),
+              identifier: nftId,
+              amount: erc1155ListingQuantity,
+            },
+          ],
+          consideration: [
+            {
+              amount: parseEther("10").toString(),
+              recipient: await offerer.getAddress(),
+            },
+            {
+              itemType: ItemType.ERC1155,
+              token: await testErc1155.getAddress(),
+              identifier: nftId,
+              recipient: await privateListingRecipient.getAddress(),
+              amount: erc1155ListingQuantity,
+            },
+          ],
+          // 2.5% fee
+          fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+        }
+      })
+
+      describe("with ETH", () => {
+        it("ERC1155 <=> ETH", async () => {
+          const { seaport } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            await privateListingRecipient.getAddress(),
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+          const recipientAddress = await privateListingRecipient.getAddress()
+
+          const ownerToTokenToIdentifierBalances =
+            await getBalancesForFulfillOrder(
+              fixture.ethers.provider,
+              order,
+              recipientAddress,
+            )
+
+          const transaction = await seaport
+            .matchAdvancedOrders({
+              orders: [
+                orderToAdvancedOrder(order),
+                orderToAdvancedOrder(counterOrder),
+              ],
+              criteriaResolvers: [],
+              fulfillments,
+              recipient: recipientAddress,
+              overrides: {
+                value: counterOrder.parameters.offer[0].startAmount,
+              },
+              accountAddress: recipientAddress,
+            })
+            .transact()
+
+          const receipt = await transaction.wait()
+
+          await verifyBalancesAfterFulfill({
+            ownerToTokenToIdentifierBalances,
+            order,
+            fulfillerAddress: recipientAddress,
+            fulfillReceipt: receipt!,
+            provider: fixture.ethers.provider,
+          })
+        })
+      })
+
+      describe("with ERC20", () => {
+        beforeEach(async () => {
+          const { testErc20 } = fixture
+
+          // Use ERC20 instead of eth
+          privateListingCreateOrderInput = {
+            ...privateListingCreateOrderInput,
+            consideration: [
+              {
+                ...privateListingCreateOrderInput.consideration[0],
+                token: await testErc20.getAddress(),
+              },
+              ...privateListingCreateOrderInput.consideration.slice(1),
+            ],
+          }
+          await testErc20.mint(
+            await privateListingRecipient.getAddress(),
+            (privateListingCreateOrderInput.consideration[0] as CurrencyItem)
+              .amount,
+          )
+        })
+
+        it("ERC1155 <=> ERC20", async () => {
+          const { seaport, testErc20 } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            await privateListingRecipient.getAddress(),
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+          const recipientAddress = await privateListingRecipient.getAddress()
+
+          const ownerToTokenToIdentifierBalances =
+            await getBalancesForFulfillOrder(
+              fixture.ethers.provider,
+              order,
+              recipientAddress,
+            )
+
+          await getTransactionMethods(
+            privateListingRecipient as unknown as Signer,
+            testErc20,
+            "approve",
+            [await seaport.contract.getAddress(), MAX_INT],
+          ).transact()
+          expect(
+            await testErc20.allowance(
+              recipientAddress,
+              await seaport.contract.getAddress(),
+            ),
+          ).to.eq(MAX_INT)
+
+          const transaction = await seaport
+            .matchAdvancedOrders({
+              orders: [
+                orderToAdvancedOrder(order),
+                orderToAdvancedOrder(counterOrder),
+              ],
+              criteriaResolvers: [],
+              fulfillments,
+              recipient: recipientAddress,
+              accountAddress: recipientAddress,
+            })
+            .transact()
+
+          const receipt = await transaction.wait()
+
+          await verifyBalancesAfterFulfill({
+            ownerToTokenToIdentifierBalances,
+            order,
+            fulfillerAddress: recipientAddress,
+            fulfillReceipt: receipt!,
+            provider: fixture.ethers.provider,
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/match-advanced-orders.spec.ts
+++ b/test/match-advanced-orders.spec.ts
@@ -124,6 +124,38 @@ describeWithFixture("As a user I want to match an advanced order", fixture => {
             provider: fixture.ethers.provider,
           })
         })
+
+        it("throws when no value override is provided for ETH orders", async () => {
+          const { seaport } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            await privateListingRecipient.getAddress(),
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+          const recipientAddress = await privateListingRecipient.getAddress()
+
+          expect(() =>
+            seaport.matchAdvancedOrders({
+              orders: [
+                orderToAdvancedOrder(order),
+                orderToAdvancedOrder(counterOrder),
+              ],
+              criteriaResolvers: [],
+              fulfillments,
+              recipient: recipientAddress,
+              accountAddress: recipientAddress,
+            }),
+          ).to.throw(
+            "Orders contain native ETH items but no `value` was provided",
+          )
+        })
       })
 
       describe("with ERC20", () => {

--- a/test/match-orders.spec.ts
+++ b/test/match-orders.spec.ts
@@ -106,6 +106,33 @@ describeWithFixture("As a user I want to match an order", fixture => {
             provider: fixture.ethers.provider,
           })
         })
+
+        it("throws when no value override is provided for ETH orders", async () => {
+          const { seaport } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const recipientAddress = await privateListingRecipient.getAddress()
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            recipientAddress,
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+
+          expect(() =>
+            seaport.matchOrders({
+              orders: [order, counterOrder],
+              fulfillments,
+              accountAddress: recipientAddress,
+            }),
+          ).to.throw(
+            "Orders contain native ETH items but no `value` was provided",
+          )
+        })
       })
 
       describe("with ERC20", () => {


### PR DESCRIPTION
## Summary
- **Native ETH validation**: Both `matchOrders` and `matchAdvancedOrders` now throw a clear error when orders contain native ETH items but no `value` override is provided, preventing opaque Seaport contract reverts.
- **Tests**: Add integration tests for `matchAdvancedOrders` covering ERC721 and ERC1155 private listings with both ETH and ERC20. Add validation tests for the new ETH check on both methods.
- **JSDoc**: Replace the vague "largely incomplete" note on both methods with clear, descriptive documentation that documents each parameter and explicitly warns about the lack of balance/approval checks.
- **Version**: Bump patch version to 4.1.2.

## Test plan
- [x] 4 new `matchAdvancedOrders` integration tests pass (ERC721<=>ETH, ERC721<=>ERC20, ERC1155<=>ETH, ERC1155<=>ERC20)
- [x] 2 new validation tests pass (missing ETH value on matchOrders and matchAdvancedOrders)
- [x] Full test suite passes (118/118)
- [x] Type check passes
- [x] Biome lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)