### PR TITLE
fix: support transaction overrides in fulfillOrders

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -937,6 +937,7 @@ export class Seaport {
    *                               Defaults to the zero address which means the offer goes to the fulfiller
    * @param input.domain optional domain to be hashed and appended to calldata
    * @param input.exactApproval optional boolean to indicate whether the approval should be exact or not
+   * @param input.overrides any transaction overrides the client wants, ignored if not set
    * @returns a use case containing the set of approval actions and fulfillment action
    */
   public async fulfillOrders({
@@ -946,6 +947,7 @@ export class Seaport {
     recipientAddress = ethers.ZeroAddress,
     domain,
     exactApproval = false,
+    overrides,
   }: {
     fulfillOrderDetails: {
       order: OrderWithCounter
@@ -960,6 +962,7 @@ export class Seaport {
     recipientAddress?: string
     domain?: string
     exactApproval?: boolean
+    overrides?: Overrides
   }) {
     if (
       fulfillOrderDetails.some(orderDetails => !orderDetails.order.signature)
@@ -1064,6 +1067,7 @@ export class Seaport {
       recipientAddress,
       domain,
       exactApproval,
+      overrides,
     })
   }
 

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -552,6 +552,7 @@ export function fulfillAvailableOrders({
   recipientAddress,
   exactApproval,
   domain,
+  overrides,
 }: {
   ordersMetadata: FulfillOrdersMetadata
   seaportContract: SeaportContract
@@ -564,6 +565,7 @@ export function fulfillAvailableOrders({
   recipientAddress: string
   exactApproval: boolean
   domain?: string
+  overrides?: Overrides
 }): OrderUseCase<
   ExchangeAction<
     ContractMethodReturnType<SeaportContract, "fulfillAvailableAdvancedOrders">
@@ -715,7 +717,7 @@ export function fulfillAvailableOrders({
     },
   )
 
-  const overrides = { value: totalNativeAmount }
+  const transactionOverrides = { ...overrides, value: totalNativeAmount }
 
   const approvalActions = getApprovalActions(
     totalInsufficientApprovals,
@@ -777,7 +779,7 @@ export function fulfillAvailableOrders({
         conduitKey,
         recipientAddress,
         advancedOrdersWithTips.length,
-        overrides,
+        transactionOverrides,
       ],
       domain,
     ),

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -717,7 +717,7 @@ export function fulfillAvailableOrders({
     },
   )
 
-  const transactionOverrides = { ...overrides, value: totalNativeAmount }
+  overrides = { ...overrides, value: totalNativeAmount }
 
   const approvalActions = getApprovalActions(
     totalInsufficientApprovals,
@@ -779,7 +779,7 @@ export function fulfillAvailableOrders({
         conduitKey,
         recipientAddress,
         advancedOrdersWithTips.length,
-        transactionOverrides,
+        overrides,
       ],
       domain,
     ),

--- a/test/fulfill-orders.spec.ts
+++ b/test/fulfill-orders.spec.ts
@@ -128,6 +128,7 @@ describeWithFixture(
 
             const thirdOrder = await thirdOrderUseCase.executeAllActions()
 
+            const gasLimit = 10_000_000n
             const { actions } = await seaport.fulfillOrders({
               fulfillOrderDetails: [
                 { order: firstOrder },
@@ -136,17 +137,17 @@ describeWithFixture(
               ],
               accountAddress: await fulfiller.getAddress(),
               domain: OPENSEA_DOMAIN,
+              overrides: { gasLimit },
             })
 
             expect(actions.length).to.eq(1)
 
             const action = actions[0]
             expect(action.type).eq("exchange")
-            expect(
-              (await action.transactionMethods.buildTransaction()).data?.slice(
-                -8,
-              ),
-            ).to.eq(OPENSEA_DOMAIN_TAG)
+            const transactionRequest =
+              await action.transactionMethods.buildTransaction()
+            expect(transactionRequest.data?.slice(-8)).to.eq(OPENSEA_DOMAIN_TAG)
+            expect(transactionRequest.gasLimit).to.eq(gasLimit)
 
             const transaction = await action.transactionMethods.transact()
             expect(transaction.data.slice(-8)).to.eq(OPENSEA_DOMAIN_TAG)


### PR DESCRIPTION
## Motivation

`fulfillOrders` did not expose transaction overrides even though `fulfillOrder` already supports them. This prevented callers from setting transaction-level fields such as `gasLimit`, `nonce`, or fee overrides when fulfilling multiple orders.

## Solution

Add `overrides` to the `fulfillOrders` input and pass it through to `fulfillAvailableOrders`.

The final transaction overrides preserve the SDK-calculated native token `value` while forwarding caller-provided fields. Added coverage that verifies a provided `gasLimit` is included in the built fulfillment transaction.
