### PR TITLE
chore: bump version to 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",


### PR DESCRIPTION
## Summary
- Bumps `@opensea/seaport-js` from 4.1.2 → 4.1.3 for release.
- Captures #876 (`fix: support transaction overrides in fulfillOrders`).

## Test plan
- [ ] Merge after #876 lands so the release includes the overrides fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)