### PR TITLE
chore(deps): consolidate and bump dependencies

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,6 +70,6 @@ jobs:
       - name: Run coverage
         run: npm run coverage
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           files: ./coverage/lcov.info

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "merkletreejs": "^0.6.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.12",
+        "@biomejs/biome": "2.5.2",
         "@nomicfoundation/hardhat-toolbox-mocha-ethers": "^3.0.0",
         "@rari-capital/solmate": "^6.4.0",
         "@types/chai-as-promised": "^8.0.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
-      "integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
+      "integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -68,20 +68,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.12",
-        "@biomejs/cli-darwin-x64": "2.4.12",
-        "@biomejs/cli-linux-arm64": "2.4.12",
-        "@biomejs/cli-linux-arm64-musl": "2.4.12",
-        "@biomejs/cli-linux-x64": "2.4.12",
-        "@biomejs/cli-linux-x64-musl": "2.4.12",
-        "@biomejs/cli-win32-arm64": "2.4.12",
-        "@biomejs/cli-win32-x64": "2.4.12"
+        "@biomejs/cli-darwin-arm64": "2.5.2",
+        "@biomejs/cli-darwin-x64": "2.5.2",
+        "@biomejs/cli-linux-arm64": "2.5.2",
+        "@biomejs/cli-linux-arm64-musl": "2.5.2",
+        "@biomejs/cli-linux-x64": "2.5.2",
+        "@biomejs/cli-linux-x64-musl": "2.5.2",
+        "@biomejs/cli-win32-arm64": "2.5.2",
+        "@biomejs/cli-win32-x64": "2.5.2"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
-      "integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
       "cpu": [
         "arm64"
       ],
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
-      "integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
       "cpu": [
         "x64"
       ],
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
-      "integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
       "cpu": [
         "arm64"
       ],
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
-      "integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
+      "integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
       "cpu": [
         "arm64"
       ],
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
-      "integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
       "cpu": [
         "x64"
       ],
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
-      "integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
+      "integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
       "cpu": [
         "x64"
       ],
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
-      "integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
+      "integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
       "cpu": [
         "arm64"
       ],
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
-      "integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
       "cpu": [
         "x64"
       ],
@@ -5124,10 +5124,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "merkletreejs": "^0.6.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.12",
+    "@biomejs/biome": "2.5.2",
     "@nomicfoundation/hardhat-toolbox-mocha-ethers": "^3.0.0",
     "@rari-capital/solmate": "^6.4.0",
     "@types/chai-as-promised": "^8.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],

--- a/test/utils/chai-plugins.d.ts
+++ b/test/utils/chai-plugins.d.ts
@@ -1,5 +1,6 @@
 declare module "chai-as-promised" {
   import type { ChaiPlugin } from "chai"
+
   const chaiAsPromised: ChaiPlugin
   export default chaiAsPromised
 }


### PR DESCRIPTION
Consolidates the open dependency bot PRs into a single PR, plus a renovate config tweak. Verified locally: `lint` ✓, `build` ✓, full test suite ✓ (118 passing).

## Included
- **@biomejs/biome** `2.4.12` → `2.5.2` (supersedes #883) — includes a one-line import-organization reformat in `test/utils/chai-plugins.d.ts` from the new version.
- **codecov/codecov-action** `v4` → `v7` (supersedes #888)
- **js-yaml** `4.1.1` → `4.3.0` (supersedes #902) — transitive via mocha, lockfile only.
- **renovate**: add `minimumReleaseAge: "7 days"` + `internalChecksFilter: "strict"` so renovate holds updates until they age past the Socket firewall's recently-published window (avoids proposing PRs that get blocked at install).

## Already satisfied on `main` (no change needed)
- #889 (shell-quote + concurrently) — `main` already ships `concurrently` v10, which resolves `shell-quote` to 1.8.4.

## Intentionally excluded (left open)
- **#901 undici v8** — unsafe here: `undici` is a transitive dep of hardhat and `@nomicfoundation/hardhat-utils` declares a `6.x` range, so forcing v8 resolves as `invalid`; v8 also requires Node ≥22.19 while `engines` is `>=20`.
- **#890 esbuild/tsx** — the installed `tsx@4.21.0` pins `esbuild@~0.27`, so `esbuild@0.28.1` is unreachable without a newer `tsx`.

Closes #883
Closes #888
Closes #902