### PR TITLE
fix: clear error when unitsToFill exceeds an order's divisibility (#904)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensea/seaport-js",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -892,8 +892,25 @@ export const getAdvancedOrderNumeratorDenominator = (
   let numerator = 1n
   let denominator = 1n
   if (unitsToFill) {
-    const unitsGcd = gcd(BigInt(unitsToFill), maxUnits)
-    numerator = BigInt(unitsToFill) / unitsGcd
+    const unitsToFillBn = BigInt(unitsToFill)
+
+    // maxUnits is the greatest common divisor of every item amount, i.e. the
+    // number of units the order can be split into while keeping every fill
+    // exact. When item amounts (e.g. once fees are added) share no common
+    // divisor, maxUnits collapses to 1 and the order is effectively
+    // non-partially-fillable. Requesting more units than that would produce a
+    // numerator/denominator greater than 1 (an over-fill), which reverts
+    // on-chain with an opaque error, so surface a clear error here instead.
+    if (unitsToFillBn > maxUnits) {
+      throw new Error(
+        `Cannot fill ${unitsToFillBn} units: this order is only divisible into ${maxUnits} unit(s). ` +
+          "This usually means the item amounts (including fees) share no common divisor, " +
+          "making the order effectively non-partially-fillable.",
+      )
+    }
+
+    const unitsGcd = gcd(unitsToFillBn, maxUnits)
+    numerator = unitsToFillBn / unitsGcd
     denominator = maxUnits / unitsGcd
   }
 

--- a/test/fulfill-units.spec.ts
+++ b/test/fulfill-units.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai"
+import type { Order } from "../src/types"
+import { getAdvancedOrderNumeratorDenominator } from "../src/utils/fulfill"
+import { getMaximumSizeForOrder } from "../src/utils/item"
+
+// Builds a minimal Order shaped just enough for the amount-based helpers under
+// test (getMaximumSizeForOrder / getAdvancedOrderNumeratorDenominator only read
+// offer/consideration start & end amounts).
+const orderWithAmounts = (
+  offerAmounts: string[],
+  considerationAmounts: string[],
+): Order =>
+  ({
+    parameters: {
+      offer: offerAmounts.map(amount => ({
+        startAmount: amount,
+        endAmount: amount,
+      })),
+      consideration: considerationAmounts.map(amount => ({
+        startAmount: amount,
+        endAmount: amount,
+      })),
+    },
+    signature: "0x",
+  }) as unknown as Order
+
+describe("units-to-fill validation (getAdvancedOrderNumeratorDenominator)", () => {
+  // An ERC721 (amount 1) listed for 10 ETH with a 2.5% fee: the amounts share
+  // no common divisor, so maxUnits collapses to 1. This is the scenario from
+  // https://github.com/ProjectOpenSea/seaport-js/issues/904
+  const feedErc721 = orderWithAmounts(
+    ["1"],
+    ["9750000000000000000", "250000000000000000"],
+  )
+
+  it("reports maxUnits of 1 for a fee'd ERC721 (non-partially-fillable)", () => {
+    expect(getMaximumSizeForOrder(feedErc721)).to.eq(1n)
+  })
+
+  it("full fills a fee'd ERC721 as 1/1 regardless of maxUnits", () => {
+    // No unitsToFill => full fill. This is why fulfillOrder(s) works today for
+    // ERC721s with fees, despite maxUnits being 1.
+    expect(getAdvancedOrderNumeratorDenominator(feedErc721)).to.deep.eq({
+      numerator: 1n,
+      denominator: 1n,
+    })
+    // Explicitly filling the single available unit is also a full fill.
+    expect(getAdvancedOrderNumeratorDenominator(feedErc721, 1)).to.deep.eq({
+      numerator: 1n,
+      denominator: 1n,
+    })
+  })
+
+  it("computes an exact fraction for a valid partial fill", () => {
+    // ERC1155 amount 6 with cleanly divisible amounts => maxUnits 6.
+    const partiallyFillable = orderWithAmounts(["6"], ["12", "6"])
+    expect(getMaximumSizeForOrder(partiallyFillable)).to.eq(6n)
+    expect(
+      getAdvancedOrderNumeratorDenominator(partiallyFillable, 4),
+    ).to.deep.eq({ numerator: 2n, denominator: 3n })
+  })
+
+  it("throws a clear error when unitsToFill exceeds the order's divisibility", () => {
+    // Requesting 2 units of an order that can only be filled as a whole would
+    // previously produce numerator/denominator 2/1 (an over-fill) and revert
+    // on-chain with an opaque NoSpecifiedOrdersAvailable error.
+    expect(() => getAdvancedOrderNumeratorDenominator(feedErc721, 2)).to.throw(
+      "Cannot fill 2 units: this order is only divisible into 1 unit(s)",
+    )
+  })
+})


### PR DESCRIPTION
Addresses #904. Bumps version to `4.1.4`.

## Diagnosis (differs from the issue)
The issue reports that `getMaximumSizeForOrder` returning `1` for fee'd ERC721 orders breaks `fulfillOrders`, and proposes clamping `maxUnits` to a minimum of `2`. Investigating against `main` (byte-identical to released 4.1.3 for these files):

- **Every test the issue lists as failing actually passes on `main`.** For a **full fill**, `getAdvancedOrderNumeratorDenominator` resolves to `1/1` regardless of `maxUnits`, so `maxUnits=1` for a fee'd ERC721 is harmless. `maxUnits` only matters on the **partial-fill** path.
- The proposed `maxUnits < 2n ? 2n` clamp would be a **no-op** for the reported (full-fill) scenario, and **silently wrong** on the partial-fill path: requesting 2 of 3 units of a coprime-amount order currently yields `2/1` (200% → reverts); the clamp turns that into `1/1`, silently filling the *entire* order instead of the requested fraction.

So the real gap is only in **partial fills**: when the requested `unitsToFill` exceeds the order's actual divisibility (`maxUnits` — the GCD of all item amounts), the SDK builds an invalid over-fill fraction that reverts on-chain with an opaque `NoSpecifiedOrdersAvailable`.

## Fix
Throw a descriptive client-side error in `getAdvancedOrderNumeratorDenominator` when `unitsToFill > maxUnits`, e.g.:

> Cannot fill 2 units: this order is only divisible into 1 unit(s). This usually means the item amounts (including fees) share no common divisor, making the order effectively non-partially-fillable.

Full fills (and valid partial fills) are unchanged, so fulfilling ERC721/ERC1155 orders with fees keeps working.

## Tests
Adds `test/fulfill-units.spec.ts`:
- fee'd ERC721 reports `maxUnits = 1`
- fee'd ERC721 full-fills as `1/1` (with and without explicit `unitsToFill: 1`)
- a valid partial fill still yields an exact fraction (`4` of `6` → `2/3`)
- over-unit partial fill throws the clear error

Full suite: **122 passing** (118 existing + 4 new), lint ✓, build ✓, types ✓.

Closes #904