### PR TITLE
fix: add missing await in getDomains to enable fallback on revert

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -1219,7 +1219,7 @@ export class Seaport {
    */
   public async getDomains(tag: string): Promise<string[]> {
     try {
-      return this.domainRegistry.getDomains(tag)
+      return await this.domainRegistry.getDomains(tag)
     } catch {
       // If there are too many domains set under the tag, it will revert when trying to return in memory.
       // This fallback will manually query each index to get the full list of domains.


### PR DESCRIPTION
## Summary

Adds missing `await` in `getDomains()` so the fallback catch block can
actually be reached when the registry reverts.

## Problem

`return this.domainRegistry.getDomains(tag)` without `await` means any
async rejection bypasses the `catch` block entirely and propagates to the
caller as an unhandled rejection. The fallback logic (per-index query) was
dead code.

## Fix

```typescript
// before
return this.domainRegistry.getDomains(tag)

// after
return await this.domainRegistry.getDomains(tag)
```

## Related

Closes #910