### PR TITLE
chore: bump version to 4.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",


### PR DESCRIPTION
## Summary
- Bump version to 4.1.5 to release the `getDomains` fallback fix from #911.

## Test plan
- [ ] CI passes (tests, lint, coverage)
- [ ] Merge and cut a GitHub Release for `v4.1.5` to trigger `npm publish`