### PR TITLE
fix: dedupe approval actions by token and operator

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -45,7 +45,7 @@ import type {
   SeaportContract,
   TipInputItem,
 } from "./types"
-import { getApprovalActions } from "./utils/approval"
+import { getApprovalActions, getApprovalDedupKey } from "./utils/approval"
 import {
   getBalancesAndApprovals,
   validateOfferBalancesAndApprovals,
@@ -255,11 +255,18 @@ export class Seaport {
 
       allOrderComponents.push(orderComponents)
 
-      // Dedupe approvals by token address
+      // Dedupe approvals by token and operator (and identifier for exact ERC721)
+      const seenApprovalKeys = new Set(
+        allApprovalActions.map(approval =>
+          getApprovalDedupKey(approval, Boolean(exactApproval)),
+        ),
+      )
+
       for (const approval of approvalActions) {
-        if (
-          allApprovalActions.find(a => a.token === approval.token) === undefined
-        ) {
+        const key = getApprovalDedupKey(approval, Boolean(exactApproval))
+
+        if (!seenApprovalKeys.has(key)) {
+          seenApprovalKeys.add(key)
           allApprovalActions.push(approval)
         }
       }

--- a/src/utils/approval.ts
+++ b/src/utils/approval.ts
@@ -32,6 +32,29 @@ export const approvedItemAmount = async (
   return MAX_INT
 }
 
+export const getApprovalDedupKey = (
+  approval: {
+    token: string
+    operator: string
+    itemType: ItemType
+    identifierOrCriteria: string
+  },
+  exactApproval: boolean,
+): string => {
+  const token = approval.token.toLowerCase()
+  const operator = approval.operator.toLowerCase()
+
+  if (
+    exactApproval &&
+    isErc721Item(approval.itemType) &&
+    !isErc1155Item(approval.itemType)
+  ) {
+    return `${token}:${operator}:${approval.identifierOrCriteria}`
+  }
+
+  return `${token}:${operator}`
+}
+
 /**
  * Get approval actions given a list of insufficient approvals.
  */
@@ -40,12 +63,21 @@ export function getApprovalActions(
   exactApproval: boolean,
   signer: Signer,
 ): ApprovalAction[] {
-  return insufficientApprovals
-    .filter(
-      (approval, index) =>
-        index === insufficientApprovals.length - 1 ||
-        insufficientApprovals[index + 1].token !== approval.token,
-    )
+  const seenApprovalKeys = new Set<string>()
+
+  return [...insufficientApprovals]
+    .reverse()
+    .filter(approval => {
+      const key = getApprovalDedupKey(approval, exactApproval)
+
+      if (seenApprovalKeys.has(key)) {
+        return false
+      }
+
+      seenApprovalKeys.add(key)
+      return true
+    })
+    .reverse()
     .map(
       ({
         token,

--- a/test/create-bulk-orders.spec.ts
+++ b/test/create-bulk-orders.spec.ts
@@ -6,6 +6,7 @@ import type {
   BasicErc721Item,
   CreateBulkOrdersAction,
 } from "../src/types"
+import { getApprovalActions } from "../src/utils/approval"
 import { generateRandomSalt } from "../src/utils/order"
 import { describeWithFixture } from "./utils/setup"
 
@@ -148,6 +149,44 @@ describeWithFixture(
 
         expect(isValid).to.be.true
       }
+    })
+
+    it("should not dedupe approval actions with the same token but different operators", async () => {
+      const { seaportContract, testErc721, ethers } = fixture
+      const [signer] = await ethers.getSigners()
+
+      const token = await testErc721.getAddress()
+      const seaportOperator = await seaportContract.getAddress()
+      const conduitOperator = "0x000000000000000000000000000000000000dEaD"
+
+      const approvalActions = getApprovalActions(
+        [
+          {
+            token,
+            operator: seaportOperator,
+            itemType: ItemType.ERC721,
+            identifierOrCriteria: "1",
+            requiredApprovedAmount: 1n,
+            approvedAmount: 0n,
+          },
+          {
+            token,
+            operator: conduitOperator,
+            itemType: ItemType.ERC721,
+            identifierOrCriteria: "2",
+            requiredApprovedAmount: 1n,
+            approvedAmount: 0n,
+          },
+        ],
+        false,
+        signer,
+      )
+
+      expect(approvalActions).to.have.lengthOf(2)
+      expect(approvalActions.map(action => action.operator)).to.deep.equal([
+        seaportOperator,
+        conduitOperator,
+      ])
     })
   },
 )


### PR DESCRIPTION
Fixes #916 

## Summary

- Deduplicate approval actions by (token, operator) instead of token alone
- Export `getApprovalDedupKey` and reuse it in `createBulkOrders`
- For exact ERC721 approvals, include `identifierOrCriteria` in the dedup key

## Problem

Approval actions were deduplicated by token address only. When the same token required approvals to different operators (e.g. Seaport vs OpenSea conduit), one approval was silently dropped in:
- `getApprovalActions` (`approval.ts`)
- `createBulkOrders` approval merge (`seaport.ts`)

## Test plan

- [x] npm run lint
- [x] npm test -- --grep "create bulk orders"