### PR TITLE
chore: bump version to 4.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensea/seaport-js",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",


### PR DESCRIPTION
Bumps to 4.1.6 to release the three bug fixes that landed since v4.1.5. All are patch-level: no new public API on the `Seaport` entry point, and no breaking changes.

## What's in it

Approval dedup ignored the operator (#917, fixes #916). Approvals were deduplicated by token address alone. When the same token needed approvals to different operators, for example Seaport versus the OpenSea conduit across bulk orders with mixed `conduitKey` values, one approval was silently dropped and fulfillment could then fail onchain for want of it. Dedup is now keyed on (token, operator), with `identifierOrCriteria` included for exact ERC721 approvals. This also fixes a second defect in the same filter, which only compared adjacent entries and so emitted redundant `setApprovalForAll` calls for non-consecutive duplicates of one token.

Criteria resolvers looked up the wrong criteria (#915). `generateCriteriaResolvers` indexed the criteria array by the item's position in the full offer or consideration array, but `offerCriterias` and `considerationCriterias` are flat arrays holding only the criteria-based items. Any order where a non-criteria item preceded a criteria item threw `TypeError: Cannot read properties of undefined (reading 'identifier')`. Lookups now go through `getItemToCriteriaMap`, matching what `fulfill.ts`, `balanceAndApprovalCheck.ts` and `item.ts` already do, and missing criteria raise a meaningful message instead.

Division by zero on zero-duration orders (#923, fixes #922). `getPresentItemAmount` threw `RangeError: Division by zero` when `startTime === endTime`, since BigInt division by `0n` throws rather than yielding `Infinity`. This affected any fulfillment path feeding order times into `timeBasedItemParams`. The guard sits below the not-yet-started branch, so a zero-duration order at or past its start returns `endAmount` instead of throwing, while one whose start is still in the future keeps returning `startAmount` as before.

For expectation-setting, a zero-duration order is never fulfillable onchain regardless, because Seaport's `_verifyTime` reverts `InvalidTime` on `endTime <= block.timestamp`. The fix replaces an opaque `RangeError` during amount derivation with a clear revert from the contract.

## Also since v4.1.5

Dependency maintenance, none of it affecting the published package: `hardhat` 3.10.0 (#919), `@biomejs/biome` 2.5.4 (#918), `actions/setup-node` v7 (#920), `c8` v12 (#921), and `immutable` 4.3.9 (#913) for [GHSA-v56q-mh7h-f735](https://github.com/immutable-js/immutable-js/security/advisories/GHSA-v56q-mh7h-f735).

## Note on the bump itself

I used `npm version 4.1.6 --no-git-tag-version`, which updates `package.json` and `package-lock.json` together. The 4.1.5 bump (#912) changed only `package.json`, so the lockfile's `version` fields drifted until a later dependency PR happened to regenerate them. This keeps them consistent.

## To release

- [ ] Merge this
- [ ] Cut a GitHub Release for `v4.1.6` to trigger `npm publish`

One thing to watch on this publish: #920 moved `npm-publish.yml` to `actions/setup-node@v7`, which drops the dummy `NODE_AUTH_TOKEN` export. That workflow only runs on `release: published`, so it has never been exercised on v7. The change should be neutral or beneficial here, since this repo publishes via Trusted Publishing (`id-token: write` plus `--provenance`, no `NPM_TOKEN`), and upstream states the dummy value "didn't break OIDC flows" while its removal avoids corrupting `.npmrc`. This is still the first release to prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
