### PR TITLE
fix: include orderIndex in ERC721 de-dup key to prevent cross order aggregation

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -774,8 +774,8 @@ export function fulfillAvailableOrders({
               ),
             })
           : [],
-        offerFulfillments as any,
-        considerationFulfillments as any,
+        offerFulfillments,
+        considerationFulfillments,
         conduitKey,
         recipientAddress,
         advancedOrdersWithTips.length,
@@ -814,12 +814,12 @@ export function generateFulfillOrdersFulfillments(
 
   const offerAggregatedFulfillments: Record<
     string,
-    FulfillmentComponentStruct
+    FulfillmentComponentStruct[]
   > = {}
 
   const considerationAggregatedFulfillments: Record<
     string,
-    FulfillmentComponentStruct
+    FulfillmentComponentStruct[]
   > = {}
 
   ordersMetadata.forEach(
@@ -840,9 +840,9 @@ export function generateFulfillOrdersFulfillments(
         })}${isErc721Item(item.itemType) ? `${orderIndex}-${itemIndex}` : ""}`
 
         offerAggregatedFulfillments[aggregateKey] = [
-          ...((offerAggregatedFulfillments[aggregateKey] ?? []) as any),
+          ...(offerAggregatedFulfillments[aggregateKey] ?? []),
           { orderIndex, itemIndex },
-        ] as any
+        ]
       })
     },
   )
@@ -864,10 +864,9 @@ export function generateFulfillOrdersFulfillments(
           })}${isErc721Item(item.itemType) ? `${orderIndex}-${itemIndex}` : ""}`
 
           considerationAggregatedFulfillments[aggregateKey] = [
-            ...((considerationAggregatedFulfillments[aggregateKey] ??
-              []) as any),
+            ...(considerationAggregatedFulfillments[aggregateKey] ?? []),
             { orderIndex, itemIndex },
-          ] as any
+          ]
         },
       )
     },

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -797,8 +797,8 @@ export function fulfillAvailableOrders({
 export function generateFulfillOrdersFulfillments(
   ordersMetadata: FulfillOrdersMetadata,
 ): {
-  offerFulfillments: FulfillmentComponentStruct[]
-  considerationFulfillments: FulfillmentComponentStruct[]
+  offerFulfillments: FulfillmentComponentStruct[][]
+  considerationFulfillments: FulfillmentComponentStruct[][]
 } {
   const hashAggregateKey = ({
     sourceOrDestination,
@@ -837,7 +837,7 @@ export function generateFulfillOrdersFulfillments(
           identifier:
             itemToCriteria.get(item)?.identifier ?? item.identifierOrCriteria,
           // We tack on the index to ensure that erc721s can never be aggregated and instead must be in separate arrays
-        })}${isErc721Item(item.itemType) ? itemIndex : ""}`
+        })}${isErc721Item(item.itemType) ? `${orderIndex}-${itemIndex}` : ""}`
 
         offerAggregatedFulfillments[aggregateKey] = [
           ...((offerAggregatedFulfillments[aggregateKey] ?? []) as any),
@@ -861,7 +861,7 @@ export function generateFulfillOrdersFulfillments(
             identifier:
               itemToCriteria.get(item)?.identifier ?? item.identifierOrCriteria,
             // We tack on the index to ensure that erc721s can never be aggregated and instead must be in separate arrays
-          })}${isErc721Item(item.itemType) ? itemIndex : ""}`
+          })}${isErc721Item(item.itemType) ? `${orderIndex}-${itemIndex}` : ""}`
 
           considerationAggregatedFulfillments[aggregateKey] = [
             ...((considerationAggregatedFulfillments[aggregateKey] ??

--- a/test/utils/fulfill.spec.ts
+++ b/test/utils/fulfill.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai"
+import { ItemType, OrderType } from "../../src/constants"
+import { generateFulfillOrdersFulfillments } from "../../src/utils/fulfill"
+import type { FulfillOrdersMetadata } from "../../src/utils/fulfill"
+
+const ZERO_ADDR = "0x0000000000000000000000000000000000000000"
+const ZERO_HASH =
+  "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+const makeErc721Order = (
+  offerer = "0x1111111111111111111111111111111111111111",
+  token = "0xNFTNFTNFTNFTNFTNFTNFTNFTNFTNFTNFTNFTNFT",
+  tokenId = "1",
+) => ({
+  parameters: {
+    offerer,
+    offer: [
+      {
+        itemType: ItemType.ERC721,
+        token,
+        identifierOrCriteria: tokenId,
+        startAmount: "1",
+        endAmount: "1",
+      },
+    ],
+    consideration: [],
+    startTime: "0",
+    endTime: "99999999999",
+    orderType: OrderType.FULL_OPEN,
+    zone: ZERO_ADDR,
+    zoneHash: ZERO_HASH,
+    salt: "0",
+    conduitKey: ZERO_HASH,
+    totalOriginalConsiderationItems: 0,
+    counter: 0n,
+  },
+  signature: "0x",
+})
+
+const makeMeta = (order: ReturnType<typeof makeErc721Order>) =>
+  ({
+    order,
+    orderStatus: {
+      isValidated: false,
+      isCancelled: false,
+      totalFilled: 0n,
+      totalSize: 1n,
+    },
+    offerCriteria: [],
+    considerationCriteria: [],
+    tips: [],
+    extraData: "0x",
+    offererBalancesAndApprovals: { balances: [], approvals: [] } as any,
+    offererOperator: ZERO_ADDR,
+  }) satisfies FulfillOrdersMetadata[number]
+
+describe("generateFulfillOrdersFulfillments", () => {
+  describe("ERC721 cross-order aggregation", () => {
+    it("keeps ERC721s from different orders in separate fulfillment groups", () => {
+      // Two orders from the same offerer for the same ERC721 token/id
+      // Without the fix both land in the same group (amount=2 → InvalidERC721TransferAmount)
+      const metadata: FulfillOrdersMetadata = [
+        makeMeta(makeErc721Order()),
+        makeMeta(makeErc721Order()),
+      ]
+
+      const { offerFulfillments } =
+        generateFulfillOrdersFulfillments(metadata)
+
+      // Must produce TWO separate groups, each with exactly ONE component
+      expect(offerFulfillments).to.have.length(2)
+      expect(offerFulfillments[0]).to.deep.equal([
+        { orderIndex: 0, itemIndex: 0 },
+      ])
+      expect(offerFulfillments[1]).to.deep.equal([
+        { orderIndex: 1, itemIndex: 0 },
+      ])
+    })
+
+    it("still aggregates ERC1155 items from different orders with same token/id", () => {
+      const makeErc1155Order = () => ({
+        ...makeErc721Order(),
+        parameters: {
+          ...makeErc721Order().parameters,
+          offer: [
+            {
+              itemType: ItemType.ERC1155,
+              token: "0xNFTNFTNFTNFTNFTNFTNFTNFTNFTNFTNFTNFTNFT",
+              identifierOrCriteria: "1",
+              startAmount: "5",
+              endAmount: "5",
+            },
+          ],
+        },
+      })
+
+      const metadata: FulfillOrdersMetadata = [
+        makeMeta(makeErc1155Order()),
+        makeMeta(makeErc1155Order()),
+      ]
+
+      const { offerFulfillments } =
+        generateFulfillOrdersFulfillments(metadata)
+
+      // ERC1155s with same token/id CAN be aggregated (amount=10 is valid)
+      expect(offerFulfillments).to.have.length(1)
+      expect(offerFulfillments[0]).to.deep.equal([
+        { orderIndex: 0, itemIndex: 0 },
+        { orderIndex: 1, itemIndex: 0 },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #926

`generateFulfillOrdersFulfillments` in `src/utils/fulfill.ts` built the ERC721
de-duplication key using only `itemIndex`, not `orderIndex`. When two orders from
the same offerer both have an ERC721 at `offer[0]` with the same token/identifier,
the keys collide and the items are merged into a single fulfillment component.
Seaport then attempts `amount = 2` on the ERC721 transfer and always reverts with
`InvalidERC721TransferAmount`.

The existing code comment already states the intent:
> "We tack on the index to ensure that erc721s can never be aggregated"

But `itemIndex` alone doesn't achieve this across orders.

## Changes

- `src/utils/fulfill.ts`: Change `itemIndex` → `` `${orderIndex}-${itemIndex}` `` in both the offer and consideration aggregation loops
- `src/utils/fulfill.ts`: Correct return type from `FulfillmentComponentStruct[]` to `FulfillmentComponentStruct[][]` (was masked by `as any` at call site)

## Testing

All 118 existing tests pass.