### PR TITLE
chore: bump version to 4.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensea/seaport-js",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",


### PR DESCRIPTION
Patch bump for the one bug fix landed since v4.1.6.

## What's in this release

[#932](https://github.com/ProjectOpenSea/seaport-js/pull/932) fixes the ERC721 de-duplication key in `generateFulfillOrdersFulfillments`. The key was suffixed with `itemIndex` alone, which separates ERC721s within a single order but not across orders, so two orders sharing offerer (or recipient), token, and identifier at the same item index collapsed into one fulfillment component and Seaport derived a transfer with `amount = 2`. The suffix is now `${orderIndex}-${itemIndex}`, which is what the comment above the line has always claimed it did. Reported and fixed by @Sertug17 in [#926](https://github.com/ProjectOpenSea/seaport-js/issues/926).

That PR also typed the two fulfillment accumulators as arrays, which removed four `as any` casts and means the `fulfillAvailableAdvancedOrders` arguments are now checked against the contract ABI rather than cast away. The public signature of `generateFulfillOrdersFulfillments` changed from `FulfillmentComponentStruct[]` to `FulfillmentComponentStruct[][]`, but the old annotation never matched what the function returned, so no runtime behavior depended on it.

The rest of the range since v4.1.6 is dependency updates: [#928](https://github.com/ProjectOpenSea/seaport-js/pull/928), [#929](https://github.com/ProjectOpenSea/seaport-js/pull/929), [#930](https://github.com/ProjectOpenSea/seaport-js/pull/930), [#931](https://github.com/ProjectOpenSea/seaport-js/pull/931).

## Notes

Bumped with `npm version patch` so `package-lock.json` stays in sync. Diff is the two version fields, nothing else.

`npx hardhat test` on this branch: 138 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)