### PR TITLE
fix: use getApprovalDedupKey in addApprovalIfNeeded for exactApproval correctness

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -23,7 +23,7 @@ import type {
   OrderWithCounter,
   SeaportContract,
 } from "../types"
-import { getApprovalActions } from "./approval"
+import { getApprovalActions, getApprovalDedupKey } from "./approval"
 import {
   type BalancesAndApprovals,
   type InsufficientApprovals,
@@ -642,9 +642,10 @@ export function fulfillAvailableOrders({
     orderInsufficientApprovals: InsufficientApprovals,
   ) => {
     orderInsufficientApprovals.forEach(insufficientApproval => {
+      const key = getApprovalDedupKey(insufficientApproval, exactApproval)
       if (
-        !totalInsufficientApprovals.find(
-          approval => approval.token === insufficientApproval.token,
+        !totalInsufficientApprovals.some(
+          approval => getApprovalDedupKey(approval, exactApproval) === key,
         )
       ) {
         totalInsufficientApprovals.push(insufficientApproval)

--- a/test/fulfill-orders.spec.ts
+++ b/test/fulfill-orders.spec.ts
@@ -1144,6 +1144,60 @@ describeWithFixture(
       })
     })
 
+
+    describe("exactApproval: true", () => {
+      it("generates a separate approve action for each ERC721 token ID when filling multiple buy orders from the same collection", async () => {
+        const { seaport, testErc721, testErc20 } = fixture
+
+        await testErc721.mint(await fulfiller.getAddress(), nftId)
+        await testErc721.mint(await fulfiller.getAddress(), nftId2)
+        await testErc20.mint(await offerer.getAddress(), parseEther("20").toString())
+        await testErc20.mint(await secondOfferer.getAddress(), parseEther("10").toString())
+
+        const firstOrder = await (
+          await seaport.createOrder({
+            offer: [{ amount: parseEther("10").toString(), token: await testErc20.getAddress() }],
+            consideration: [{ itemType: ItemType.ERC721, token: await testErc721.getAddress(), identifier: nftId, recipient: await offerer.getAddress() }],
+            fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+          })
+        ).executeAllActions()
+
+        const secondOrder = await (
+          await seaport.createOrder(
+            {
+              offer: [{ amount: parseEther("10").toString(), token: await testErc20.getAddress() }],
+              consideration: [{ itemType: ItemType.ERC721, token: await testErc721.getAddress(), identifier: nftId2, recipient: await secondOfferer.getAddress() }],
+              fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+            },
+            await secondOfferer.getAddress(),
+          )
+        ).executeAllActions()
+
+        const { actions } = await seaport.fulfillOrders({
+          fulfillOrderDetails: [{ order: firstOrder }, { order: secondOrder }],
+          accountAddress: await fulfiller.getAddress(),
+          exactApproval: true,
+        })
+
+        // With exactApproval=true, each token ID needs its own approve() call.
+        // Before the fix, addApprovalIfNeeded deduped by token only, so
+        // the approval for nftId2 was silently dropped.
+        const nftApprovals = actions.filter(
+          a => a.type === "approval" && a.token === (await testErc721.getAddress()),
+        )
+        expect(nftApprovals.length).to.equal(2)
+        expect(nftApprovals.map(a => a.identifierOrCriteria)).to.have.members([nftId, nftId2])
+
+        for (const action of actions.filter(a => a.type === "approval")) {
+          await action.transactionMethods.transact()
+        }
+
+        await actions[actions.length - 1].transactionMethods.transact()
+
+        expect(await testErc721.ownerOf(nftId)).to.equal(await offerer.getAddress())
+        expect(await testErc721.ownerOf(nftId2)).to.equal(await secondOfferer.getAddress())
+      })
+    })
     // TODO
     describe("Special use cases", () => {
       it("Can fulfill dutch auction orders", () => {})

--- a/test/fulfill-orders.spec.ts
+++ b/test/fulfill-orders.spec.ts
@@ -3,7 +3,11 @@ import { expect } from "chai"
 import { parseEther } from "ethers"
 import { ItemType, MAX_INT } from "../src/constants"
 import type { TestERC721, TestERC1155 } from "../src/typechain-types/index"
-import type { ApprovalAction, CreateOrderInput, CurrencyItem } from "../src/types"
+import type {
+  ApprovalAction,
+  CreateOrderInput,
+  CurrencyItem,
+} from "../src/types"
 import { getTagFromDomain } from "../src/utils/usecase"
 import { OPENSEA_DOMAIN, OPENSEA_DOMAIN_TAG } from "./utils/constants"
 import { describeWithFixture } from "./utils/setup"
@@ -1144,30 +1148,57 @@ describeWithFixture(
       })
     })
 
-
     describe("exactApproval: true", () => {
       it("generates a separate approve action for each ERC721 token ID when filling multiple buy orders from the same collection", async () => {
         const { seaport, testErc721, testErc20 } = fixture
 
         await testErc721.mint(await fulfiller.getAddress(), nftId)
         await testErc721.mint(await fulfiller.getAddress(), nftId2)
-        await testErc20.mint(await offerer.getAddress(), parseEther("20").toString())
-        await testErc20.mint(await secondOfferer.getAddress(), parseEther("10").toString())
+        await testErc20.mint(
+          await offerer.getAddress(),
+          parseEther("20").toString(),
+        )
+        await testErc20.mint(
+          await secondOfferer.getAddress(),
+          parseEther("10").toString(),
+        )
 
         const firstOrder = await (
           await seaport.createOrder({
-            offer: [{ amount: parseEther("10").toString(), token: await testErc20.getAddress() }],
-            consideration: [{ itemType: ItemType.ERC721, token: await testErc721.getAddress(), identifier: nftId, recipient: await offerer.getAddress() }],
-            fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+            offer: [
+              {
+                amount: parseEther("10").toString(),
+                token: await testErc20.getAddress(),
+              },
+            ],
+            consideration: [
+              {
+                itemType: ItemType.ERC721,
+                token: await testErc721.getAddress(),
+                identifier: nftId,
+                recipient: await offerer.getAddress(),
+              },
+            ],
           })
         ).executeAllActions()
 
         const secondOrder = await (
           await seaport.createOrder(
             {
-              offer: [{ amount: parseEther("10").toString(), token: await testErc20.getAddress() }],
-              consideration: [{ itemType: ItemType.ERC721, token: await testErc721.getAddress(), identifier: nftId2, recipient: await secondOfferer.getAddress() }],
-              fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+              offer: [
+                {
+                  amount: parseEther("10").toString(),
+                  token: await testErc20.getAddress(),
+                },
+              ],
+              consideration: [
+                {
+                  itemType: ItemType.ERC721,
+                  token: await testErc721.getAddress(),
+                  identifier: nftId2,
+                  recipient: await secondOfferer.getAddress(),
+                },
+              ],
             },
             await secondOfferer.getAddress(),
           )
@@ -1188,7 +1219,10 @@ describeWithFixture(
             action.type === "approval" && action.token === erc721Address,
         )
         expect(nftApprovals.length).to.equal(2)
-        expect(nftApprovals.map(a => a.identifierOrCriteria)).to.have.members([nftId, nftId2])
+        expect(nftApprovals.map(a => a.identifierOrCriteria)).to.have.members([
+          nftId,
+          nftId2,
+        ])
 
         for (const action of actions.filter(a => a.type === "approval")) {
           await action.transactionMethods.transact()
@@ -1196,8 +1230,12 @@ describeWithFixture(
 
         await actions[actions.length - 1].transactionMethods.transact()
 
-        expect(await testErc721.ownerOf(nftId)).to.equal(await offerer.getAddress())
-        expect(await testErc721.ownerOf(nftId2)).to.equal(await secondOfferer.getAddress())
+        expect(await testErc721.ownerOf(nftId)).to.equal(
+          await offerer.getAddress(),
+        )
+        expect(await testErc721.ownerOf(nftId2)).to.equal(
+          await secondOfferer.getAddress(),
+        )
       })
     })
     // TODO

--- a/test/fulfill-orders.spec.ts
+++ b/test/fulfill-orders.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai"
 import { parseEther } from "ethers"
 import { ItemType, MAX_INT } from "../src/constants"
 import type { TestERC721, TestERC1155 } from "../src/typechain-types/index"
-import type { CreateOrderInput, CurrencyItem } from "../src/types"
+import type { ApprovalAction, CreateOrderInput, CurrencyItem } from "../src/types"
 import { getTagFromDomain } from "../src/utils/usecase"
 import { OPENSEA_DOMAIN, OPENSEA_DOMAIN_TAG } from "./utils/constants"
 import { describeWithFixture } from "./utils/setup"
@@ -1182,8 +1182,10 @@ describeWithFixture(
         // With exactApproval=true, each token ID needs its own approve() call.
         // Before the fix, addApprovalIfNeeded deduped by token only, so
         // the approval for nftId2 was silently dropped.
+        const erc721Address = await testErc721.getAddress()
         const nftApprovals = actions.filter(
-          a => a.type === "approval" && a.token === (await testErc721.getAddress()),
+          (action): action is ApprovalAction =>
+            action.type === "approval" && action.token === erc721Address,
         )
         expect(nftApprovals.length).to.equal(2)
         expect(nftApprovals.map(a => a.identifierOrCriteria)).to.have.members([nftId, nftId2])


### PR DESCRIPTION
Fixes #934

## Motivation

When `fulfillOrders` is called with `exactApproval: true` and multiple orders whose consideration includes ERC721 tokens from the **same contract** (different token IDs), the fulfiller's on-chain transaction silently reverts.

Root cause: `addApprovalIfNeeded` inside `fulfillAvailableOrders` deduplicates insufficient approvals by **token address only**:

```ts
!totalInsufficientApprovals.find(
  approval => approval.token === insufficientApproval.token,
)
```

For `exactApproval: false` this is harmless one `setApprovalForAll` covers all token IDs. But for `exactApproval: true`, the library must emit a separate `approve(tokenId)` per NFT. The token-only dedup discards every additional NFT from the same collection before `getApprovalActions` ever sees it.

There are no tests for `exactApproval: true` in `fulfill-orders.spec.ts`, which is why this was not caught.

## Solution

Replace the token-only comparison with `getApprovalDedupKey` the same function `createBulkOrders` already uses for approval deduplication. For `exactApproval: true` + ERC721, this returns `token:operator:identifierOrCriteria`, ensuring each token ID gets its own approval action.

3 lines changed in `src/utils/fulfill.ts`.