### PR TITLE
fix: reject fees exceeding 100% before they produce a malformed order

### DIFF
--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -57,6 +57,17 @@ export const deductFees = <T extends Item>(
     0,
   )
 
+  // Fees are deducted from the order's currency consideration items. A total
+  // above 100% (ONE_HUNDRED_PERCENT_BP) would deduct more than the item amount,
+  // producing a negative consideration amount and a malformed order that later
+  // reverts opaquely at ABI-encode time, so surface a clear error here instead.
+  if (totalBasisPoints > Number(ONE_HUNDRED_PERCENT_BP)) {
+    throw new Error(
+      `Total fee basisPoints (${totalBasisPoints}) cannot exceed ${ONE_HUNDRED_PERCENT_BP} (100%). ` +
+        "Fees are deducted from the order's consideration items, so a higher total would produce negative item amounts.",
+    )
+  }
+
   return items.map(item => ({
     ...item,
     startAmount: isCurrencyItem(item)

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from "chai"
+import { ItemType } from "../../src/constants"
+import type { ConsiderationItem } from "../../src/types"
+import { deductFees } from "../../src/utils/order"
+
+// deductFees subtracts the summed fee basisPoints from every currency item and
+// is the point where an out-of-range fee first turns an order malformed: a total
+// above 100% (10000 bp) makes the deduction larger than the item amount, leaving
+// a negative consideration amount that later fails opaquely at ABI-encode time.
+describe("deductFees fee-basisPoints bound", () => {
+  const currencyItem = (amount: string): ConsiderationItem => ({
+    itemType: ItemType.ERC20,
+    token: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+    identifierOrCriteria: "0",
+    startAmount: amount,
+    endAmount: amount,
+    recipient: "0x0000000000000000000000000000000000000000",
+  })
+
+  it("deducts a normal fee without altering the item below zero", () => {
+    const [item] = deductFees(
+      [currencyItem("100")],
+      [
+        {
+          recipient: "0x0000000000000000000000000000000000000001",
+          basisPoints: 250,
+        },
+      ],
+    )
+    expect(item.startAmount).to.eq("98")
+    expect(item.endAmount).to.eq("98")
+  })
+
+  it("allows a total of exactly 100% (item amount becomes zero, not negative)", () => {
+    const [item] = deductFees(
+      [currencyItem("100")],
+      [
+        {
+          recipient: "0x0000000000000000000000000000000000000001",
+          basisPoints: 10000,
+        },
+      ],
+    )
+    expect(item.startAmount).to.eq("0")
+    expect(item.endAmount).to.eq("0")
+  })
+
+  it("throws a clear error when total fee basisPoints exceed 100%", () => {
+    expect(() =>
+      deductFees(
+        [currencyItem("100")],
+        [
+          {
+            recipient: "0x0000000000000000000000000000000000000001",
+            basisPoints: 7500,
+          },
+          {
+            recipient: "0x0000000000000000000000000000000000000002",
+            basisPoints: 7500,
+          },
+        ],
+      ),
+    ).to.throw("Total fee basisPoints (15000) cannot exceed 10000 (100%)")
+  })
+
+  it("throws for a single fee above 100% rather than emitting a negative amount", () => {
+    expect(() =>
+      deductFees(
+        [currencyItem("100")],
+        [
+          {
+            recipient: "0x0000000000000000000000000000000000000001",
+            basisPoints: 10001,
+          },
+        ],
+      ),
+    ).to.throw("Total fee basisPoints (10001) cannot exceed 10000 (100%)")
+  })
+})


### PR DESCRIPTION
## Problem

`deductFees` subtracts the summed fee `basisPoints` from every currency consideration item. Nothing bounds that total, so when it exceeds `ONE_HUNDRED_PERCENT_BP` the deduction is larger than the item amount and the consideration ends up negative.

That doesn't fail where the mistake was made. The malformed order is built successfully, carried through, and only reverts later at ABI-encode time — by which point the error says nothing about fees.

Concretely, two fees of 100% and 50% on a 100-unit item produce a fee item with `startAmount: "150"`, larger than the base amount it was taken from.

## Fix

Throw a descriptive client-side error when the fee total exceeds 100%, before the order is constructed.

This follows the same shape as #906 — reject an out-of-range caller value early with a clear message rather than letting it become an opaque downstream failure — and matches the validation already in `_formatOrder` ("All currency tokens ... must be the same") and the `unitsToFill` divisibility guard.

Exactly 100% is still allowed: the item amount becomes zero, which is degenerate but not malformed.

## Tests

Four cases in `test/utils/order.spec.ts`:

- a normal 2.5% fee still deducts correctly
- exactly 100% is accepted and yields zero
- two fees summing to 150% throw
- a single fee of 100.01% throws

Verified failing-first: with the guard reverted, the two throwing cases fail and the two baseline cases pass. Suite goes from 138 to 142 passing, 0 failing. `check-types` and `biome check` both clean.

## Scope note

There's no documented bound on `basisPoints` in the types, JSDoc, or README, so this is an input-validation gap rather than a broken documented contract. The case for guarding it is that the current behaviour is silently wrong rather than merely unvalidated — a negative consideration amount is never a valid order, and surfacing that at the call site is strictly more useful than an encode-time revert.
