### PR TITLE
docs: use current Alchemy RPC endpoint in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import { Seaport } from "@opensea/seaport-js";
 import { ethers } from "ethers";
 
 const provider = new ethers.JsonRpcProvider(
-  "https://<network>.alchemyapi.io/v2/YOUR-API-KEY",
+  "https://<network>.g.alchemy.com/v2/YOUR-API-KEY",
 );
 
 const seaport = new Seaport(provider);
@@ -72,7 +72,7 @@ import { ethers } from "ethers";
 
 // Provider must be provided to the signer when supplying a custom signer
 const provider = new ethers.JsonRpcProvider(
-  "https://<network>.alchemyapi.io/v2/YOUR-API-KEY",
+  "https://<network>.g.alchemy.com/v2/YOUR-API-KEY",
 );
 
 const signer = new ethers.Wallet("YOUR_PK", provider);


### PR DESCRIPTION
## Summary

README examples still used deprecated `alchemyapi.io`. Switch to `g.alchemy.com`.

## Testing

- Diff-only README change