### PR TITLE
fix empty overrides handling in transaction methods

### DIFF
--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -61,11 +61,15 @@ const instanceOfOverrides = <T extends Overrides>(
     "overrides",
   ]
 
-  return (
-    obj === undefined ||
-    (Object.keys(obj).length > 0 &&
-      Object.keys(obj).every(key => validKeys.includes(key)))
-  )
+  if (obj === undefined) {
+    return true
+  }
+
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    return false
+  }
+
+  return Object.keys(obj).every(key => validKeys.includes(key))
 }
 
 export type ContractMethodReturnType<

--- a/test/cancel.spec.ts
+++ b/test/cancel.spec.ts
@@ -134,4 +134,24 @@ describeWithFixture("As a user I want to cancel an order", fixture => {
     )
     expect(cancelOrdersTx.gasLimit).to.eq(OVERRIDE_GAS_LIMIT)
   })
+
+  it("treats empty overrides as a no-op", async () => {
+    const { seaport } = fixture
+
+    const { executeAllActions } = await seaport.createOrder(
+      standardCreateOrderInput,
+    )
+    const order = await executeAllActions()
+
+    const tx = await seaport
+      .cancelOrders(
+        [order.parameters],
+        await offerer.getAddress(),
+        undefined,
+        {},
+      )
+      .buildTransaction()
+
+    expect(tx.to).to.equal(await fixture.seaportContract.getAddress())
+  })
 })


### PR DESCRIPTION
## Motivation

Passing an empty overrides object currently leaves it in the contract args instead of treating it as overrides. For example, `cancelOrders(..., {})` ends up calling ethers with `[orders, {}, {}]` and fails with `no matching fragment`.

## Solution

Treat plain empty objects as valid overrides, while still avoiding false positives for primitive args and arrays. Added a regression test around `cancelOrders(..., {})`.

Validated locally with:

- `npm run build`
- `npm run lint`
- `npm run test`
- `npm run coverage`
- `npm run format:check`
