### PR TITLE
fix(utils): normalize negative inputs in gcd and add empty array guard to findGcd

### DIFF
--- a/src/utils/gcd.ts
+++ b/src/utils/gcd.ts
@@ -1,8 +1,11 @@
 import type { BigNumberish } from "ethers"
 
 export const gcd = (a: BigNumberish, b: BigNumberish): bigint => {
-  const bnA = BigInt(a)
-  const bnB = BigInt(b)
+  let bnA = BigInt(a)
+  let bnB = BigInt(b)
+
+  bnA = bnA < 0n ? -bnA : bnA
+  bnB = bnB < 0n ? -bnB : bnB
 
   if (bnA === 0n) {
     return bnB
@@ -11,8 +14,13 @@ export const gcd = (a: BigNumberish, b: BigNumberish): bigint => {
   return gcd(bnB % bnA, bnA)
 }
 
-export const findGcd = (elements: BigNumberish[]) => {
+export const findGcd = (elements: BigNumberish[]): bigint => {
+  if (elements.length === 0) {
+    return 0n
+  }
+
   let result = BigInt(elements[0])
+  result = result < 0n ? -result : result
 
   for (let i = 1; i < elements.length; i++) {
     result = gcd(elements[i], result)

--- a/test/utils/gcd.spec.ts
+++ b/test/utils/gcd.spec.ts
@@ -1,0 +1,38 @@
+import { expect } from "chai"
+import { findGcd, gcd } from "../../src/utils/gcd"
+
+describe("gcd utils", () => {
+  describe("gcd", () => {
+    it("calculates correct GCD for positive numbers", () => {
+      expect(gcd(12, 18)).to.equal(6n)
+      expect(gcd("100", "25")).to.equal(25n)
+    })
+
+    it("handles zero correctly", () => {
+      expect(gcd(0, 5)).to.equal(5n)
+      expect(gcd(7, 0)).to.equal(7n)
+    })
+
+    it("normalizes negative values to positive GCD", () => {
+      expect(gcd(-12, 18)).to.equal(6n)
+      expect(gcd(12, -18)).to.equal(6n)
+      expect(gcd(-12, -18)).to.equal(6n)
+      expect(gcd(0, -5)).to.equal(5n)
+    })
+  })
+
+  describe("findGcd", () => {
+    it("finds GCD of multiple elements", () => {
+      expect(findGcd([24, 36, 60])).to.equal(12n)
+      expect(findGcd(["10", "20", "30"])).to.equal(10n)
+    })
+
+    it("returns 0n for empty array without throwing TypeError", () => {
+      expect(findGcd([])).to.equal(0n)
+    })
+
+    it("handles negative array elements", () => {
+      expect(findGcd([-24, 36, -60])).to.equal(12n)
+    })
+  })
+})


### PR DESCRIPTION
Updated gcd and findGcd in src/utils/gcd.ts. Added an empty array check in findGcd to prevent throwing TypeError: Cannot convert undefined to a BigInt when passed an empty array. Also normalized inputs in gcd to absolute values to guarantee non-negative GCD outputs per mathematical definition. Added unit test coverage.