### PR TITLE
fix: sum token amounts case-insensitively in getSummedTokenAndIdentifierAmounts

### DIFF
--- a/src/utils/item.ts
+++ b/src/utils/item.ts
@@ -106,15 +106,19 @@ export const getSummedTokenAndIdentifierAmounts = ({
   >((map, item) => {
     const identifierOrCriteria =
       itemToCriteria.get(item)?.identifier ?? item.identifierOrCriteria
+    // The same token can arrive in different casings (e.g. checksummed from one
+    // source, lowercased from another). Normalize the key so those items are
+    // summed into a single bucket, matching the case-insensitive lookup done by
+    // findBalanceAndApproval.
+    const token = item.token.toLowerCase()
 
     return {
       ...map,
-      [item.token]: {
-        ...map[item.token],
+      [token]: {
+        ...map[token],
         // Being explicit about the undefined type as it's possible for it to be undefined at first iteration
         [identifierOrCriteria]:
-          ((map[item.token]?.[identifierOrCriteria] as bigint | undefined) ??
-            0n) +
+          ((map[token]?.[identifierOrCriteria] as bigint | undefined) ?? 0n) +
           getPresentItemAmount({
             startAmount: item.startAmount,
             endAmount: item.endAmount,

--- a/test/utils/item.spec.ts
+++ b/test/utils/item.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from "chai"
-import { getPresentItemAmount } from "../../src/utils/item"
+import { ItemType } from "../../src/constants"
+import type { Item } from "../../src/types"
+import {
+  getPresentItemAmount,
+  getSummedTokenAndIdentifierAmounts,
+} from "../../src/utils/item"
 
 describe("getPresentItemAmount", () => {
   describe("zero-duration order (startTime === endTime)", () => {
@@ -65,5 +70,28 @@ describe("getPresentItemAmount", () => {
       })
       expect(result).to.equal(1000n)
     })
+  })
+})
+
+describe("getSummedTokenAndIdentifierAmounts", () => {
+  const erc20Item = (token: string, amount: string): Item => ({
+    itemType: ItemType.ERC20,
+    token,
+    identifierOrCriteria: "0",
+    startAmount: amount,
+    endAmount: amount,
+  })
+
+  it("sums amounts for the same token regardless of address casing", () => {
+    const checksummed = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+    const lowercased = checksummed.toLowerCase()
+
+    const result = getSummedTokenAndIdentifierAmounts({
+      items: [erc20Item(checksummed, "100"), erc20Item(lowercased, "200")],
+      criterias: [],
+    })
+
+    expect(Object.keys(result)).to.deep.equal([lowercased])
+    expect(result[lowercased]["0"]).to.equal(300n)
   })
 })


### PR DESCRIPTION
## Problem

`getSummedTokenAndIdentifierAmounts` keys its accumulator on the raw `item.token` string:

```ts
[item.token]: {
  ...map[item.token],
```

Token addresses reach this function from several sources. Order items typically arrive lowercased from an API, while `tips` are constructed by the caller and are commonly checksummed. When the same token appears in both casings, the amounts land in two separate buckets.

`getInsufficientBalanceAndApprovalAmounts` then walks those buckets and compares each one against the owner's full balance independently. An order requiring 100 + 200 of the same ERC20 from a wallet holding 250 passes the check, because neither bucket alone exceeds the balance. The revert surfaces on-chain instead of in the pre-flight check the library exists to provide.

## Fix

Normalize the accumulator key with `toLowerCase()`. This matches the behaviour `findBalanceAndApproval` already relies on, which compares both `token` and `identifierOrCriteria` case-insensitively, so the summation and the lookup now agree.

Native-token lookups are unaffected: callers read the map at `ethers.ZeroAddress`, which contains no alphabetic characters.

## Test

Added a unit test in `test/utils/item.spec.ts` covering the same ERC20 supplied in checksummed and lowercased form. It fails on `main` (two keys, `100n` and `200n`) and passes with the fix (one key, `300n`).

Full suite: 139 passing.