### PR TITLE
fix: encode buffers as hex without BigNumberish coercion

### DIFF
--- a/src/utils/eip712/utils.ts
+++ b/src/utils/eip712/utils.ts
@@ -1,5 +1,5 @@
 import type { BytesLike } from "ethers"
-import { concat, keccak256, toBeHex } from "ethers"
+import { concat, keccak256 } from "ethers"
 
 export const makeArray = <T>(len: number, getValue: (i: number) => T) =>
   Array(len)
@@ -12,7 +12,7 @@ export const chunk = <T>(array: T[], size: number) => {
   )
 }
 
-export const bufferToHex = (buf: Buffer) => toBeHex(buf.toString("hex"))
+export const bufferToHex = (buf: Buffer) => `0x${buf.toString("hex")}`
 
 export const hexToBuffer = (value: string) => Buffer.from(value.slice(2), "hex")
 

--- a/test/utils/eip712-utils.spec.ts
+++ b/test/utils/eip712-utils.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai"
+import { bufferToHex, hexToBuffer } from "../../src/utils/eip712/utils"
+
+describe("eip712 utils", () => {
+  describe("bufferToHex", () => {
+    it("prefixes the hex encoding with 0x without interpreting it as a BigNumberish", () => {
+      const buf = Buffer.from("abcd", "hex")
+
+      expect(bufferToHex(buf)).to.eq("0xabcd")
+    })
+
+    it("preserves full-width zero buffers", () => {
+      const buf = Buffer.alloc(32)
+
+      expect(bufferToHex(buf)).to.eq(`0x${"00".repeat(32)}`)
+    })
+
+    it("round-trips with hexToBuffer", () => {
+      const buf = Buffer.from("deadbeef", "hex")
+
+      expect(hexToBuffer(bufferToHex(buf))).to.deep.eq(buf)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fix `bufferToHex` to prefix buffer hex with `0x` instead of passing a bare hex string to `toBeHex`
- Add unit tests for `0x` prefixing, full-width zero buffers, and round-trip with `hexToBuffer`
- 
## Problem

`bufferToHex` used `toBeHex(buf.toString("hex"))`. ethers treats a hex string without `0x` as a BigNumberish decimal string, so non-zero buffers throw:
    invalid BigNumberish string: Cannot convert abcd to a BigInt
This breaks `getBulkOrderHash()`, which depends on `bufferToHex` for the merkle root.

## Test plan

- [x] npm run lint
- [x] npm test -- --grep "eip712 utils"