### PR TITLE
fix: account for tips when choosing the basic fulfill route

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -884,7 +884,11 @@ export class Seaport {
     if (
       !unitsToFill &&
       isRecipientSelf &&
-      shouldUseBasicFulfill(sanitizedOrder.parameters, totalFilled)
+      shouldUseBasicFulfill(
+        sanitizedOrder.parameters,
+        totalFilled,
+        tipConsiderationItems,
+      )
     ) {
       // TODO: Use fulfiller proxy if there are approvals needed directly, but none needed for proxy
       return fulfillBasicOrder(

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -74,6 +74,7 @@ import {
 export const shouldUseBasicFulfill = (
   { offer, consideration, offerer }: OrderParameters,
   totalFilled: OrderStatus["totalFilled"],
+  tips: ConsiderationItem[] = [],
 ) => {
   // 1. The order must not be partially filled
   if (totalFilled !== 0n) {
@@ -85,7 +86,11 @@ export const shouldUseBasicFulfill = (
     return false
   }
 
-  const allItems = [...offer, ...consideration]
+  // Tips are passed to Seaport as additional recipients on the basic order, so
+  // they have to satisfy the same constraints as the order's own consideration.
+  const considerationIncludingTips = [...consideration, ...tips]
+
+  const allItems = [...offer, ...considerationIncludingTips]
 
   const nfts = allItems.filter(({ itemType }) =>
     [ItemType.ERC721, ItemType.ERC1155].includes(itemType),
@@ -108,7 +113,12 @@ export const shouldUseBasicFulfill = (
   }
 
   // 5. All currencies need to have the same address and item type (Native, ERC20)
-  if (!areAllCurrenciesSame({ offer, consideration })) {
+  if (
+    !areAllCurrenciesSame({
+      offer,
+      consideration: considerationIncludingTips,
+    })
+  ) {
     return false
   }
 
@@ -121,7 +131,7 @@ export const shouldUseBasicFulfill = (
     return false
   }
 
-  const [firstConsideration, ...restConsideration] = consideration
+  const [firstConsideration, ...restConsideration] = considerationIncludingTips
 
   // 7. First consideration item must contain the offerer as the recipient
   const firstConsiderationRecipientIsNotOfferer =
@@ -136,7 +146,7 @@ export const shouldUseBasicFulfill = (
   // amount is not less than the sum of all consideration item amounts excluding the
   // first consideration item amount
   if (
-    consideration.length > 1 &&
+    considerationIncludingTips.length > 1 &&
     restConsideration.every(item => item.itemType === offer[0].itemType) &&
     totalItemsAmount(restConsideration).endAmount > BigInt(offer[0].endAmount)
   ) {

--- a/test/fulfill-utils.spec.ts
+++ b/test/fulfill-utils.spec.ts
@@ -7,7 +7,10 @@ import type {
   OrderParameters,
 } from "../src/types"
 import type { FulfillOrdersMetadata } from "../src/utils/fulfill"
-import { generateFulfillOrdersFulfillments } from "../src/utils/fulfill"
+import {
+  generateFulfillOrdersFulfillments,
+  shouldUseBasicFulfill,
+} from "../src/utils/fulfill"
 
 const OFFERER = "0x1111111111111111111111111111111111111111"
 const RECIPIENT = "0x2222222222222222222222222222222222222222"
@@ -159,5 +162,51 @@ describe("generateFulfillOrdersFulfillments", () => {
         ],
       ])
     })
+  })
+})
+
+describe("shouldUseBasicFulfill", () => {
+  const ERC20_TOKEN = "0x4444444444444444444444444444444444444444"
+
+  const nativeItem = (amount = "1000"): ConsiderationItem => ({
+    itemType: ItemType.NATIVE,
+    token: ZERO_ADDR,
+    identifierOrCriteria: "0",
+    startAmount: amount,
+    endAmount: amount,
+    recipient: OFFERER,
+  })
+
+  const erc20Item = (amount = "10"): ConsiderationItem => ({
+    itemType: ItemType.ERC20,
+    token: ERC20_TOKEN,
+    identifierOrCriteria: "0",
+    startAmount: amount,
+    endAmount: amount,
+    recipient: RECIPIENT,
+  })
+
+  const listing = makeOrder({
+    offer: [erc721Item()],
+    consideration: [nativeItem()],
+  })
+
+  it("uses basic fulfill for a plain native listing", () => {
+    expect(shouldUseBasicFulfill(listing.parameters, 0n)).to.equal(true)
+  })
+
+  it("still uses basic fulfill when a tip shares the order's currency", () => {
+    expect(
+      shouldUseBasicFulfill(listing.parameters, 0n, [nativeItem("5")]),
+    ).to.equal(true)
+  })
+
+  it("falls back to standard fulfill when a tip uses a different currency", () => {
+    // fulfillBasicOrder passes tips through additionalRecipients, which Seaport
+    // pays out in considerationToken. An ERC20 tip on a native order would be
+    // paid as native currency, so the basic route must be rejected here.
+    expect(
+      shouldUseBasicFulfill(listing.parameters, 0n, [erc20Item()]),
+    ).to.equal(false)
   })
 })


### PR DESCRIPTION
## Problem

`fulfillOrder` picks between the basic and standard routes with:

```ts
shouldUseBasicFulfill(sanitizedOrder.parameters, totalFilled)
```

`tipConsiderationItems` is built a few lines above this call, but is not passed in. Everywhere else in the same flow tips are treated as consideration: `fulfillBasicOrder` appends them to `additionalRecipients`, computes `totalNativeAmount` over `considerationIncludingTips`, and `validateBasicFulfillBalancesAndApprovals` validates against `[...consideration, ...tips]`. The route decision is the one place they are dropped.

Seaport pays every entry in `additionalRecipients` in `considerationToken`. So for a native listing fulfilled with an ERC20 tip, `shouldUseBasicFulfill` still returns `true`, and the resulting `fulfillBasicOrder` call asks Seaport to pay the tip recipient in ETH rather than the ERC20 the caller specified. Rule 5 (all currencies must match) is exactly the guard that should have caught this, but it only ever saw the order's own consideration.

The same gap applies to the other consideration-wide rules: a tip with `startAmount !== endAmount` (rule 6), or one that pushes the additional-recipient total past the offered amount on a same-currency order (rule 8), slips through as well.

## Fix

`shouldUseBasicFulfill` now takes the tips as an optional third argument and applies rules 5, 6, 8 and 9 to `[...consideration, ...tips]`. Rule 2 still checks the order's own consideration, since a tip cannot stand in for a missing consideration item. When the combined set does not satisfy the basic-order constraints, fulfillment falls back to the standard route, which handles mixed currencies correctly.

The parameter defaults to `[]`, so existing callers are unaffected.

## Test

Added three cases to `test/fulfill-utils.spec.ts`:

- a plain native listing still takes the basic route
- a tip in the order's own currency still takes the basic route
- an ERC20 tip on a native listing does not

The third fails on `main` (`expected true to equal false`) and passes with the fix.

Full suite: 141 passing. `tsc --noEmit` clean.