### PR TITLE
fix: use nullish check for overrides.value in _validateMatchOrdersNativeValue

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -1260,7 +1260,7 @@ export class Seaport {
         params.consideration.some(item => item.itemType === ItemType.NATIVE),
     )
 
-    if (hasNativeToken && !overrides?.value) {
+    if (hasNativeToken && overrides?.value == null) {
       throw new Error(
         "Orders contain native ETH items but no `value` was provided in overrides. " +
           "Pass the required ETH amount via `overrides: { value }` to avoid a revert.",

--- a/test/match-orders.spec.ts
+++ b/test/match-orders.spec.ts
@@ -133,6 +133,34 @@ describeWithFixture("As a user I want to match an order", fixture => {
             "Orders contain native ETH items but no `value` was provided",
           )
         })
+
+        it("does not throw when value is explicitly 0n for ETH orders", async () => {
+          const { seaport } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const recipientAddress = await privateListingRecipient.getAddress()
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            recipientAddress,
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+
+          // Regression: !overrides?.value treats 0n as falsy and incorrectly
+          // throws. overrides?.value == null must be used instead.
+          expect(() =>
+            seaport.matchOrders({
+              orders: [order, counterOrder],
+              fulfillments,
+              overrides: { value: 0n },
+              accountAddress: recipientAddress,
+            }),
+          ).not.to.throw()
+        })
       })
 
       describe("with ERC20", () => {

--- a/test/match-orders.spec.ts
+++ b/test/match-orders.spec.ts
@@ -161,6 +161,42 @@ describeWithFixture("As a user I want to match an order", fixture => {
             }),
           ).not.to.throw()
         })
+
+        it("does not throw when value is explicitly 0n for ETH orders (matchAdvancedOrders)", async () => {
+          const { seaport } = fixture
+
+          const { executeAllActions } = await seaport.createOrder(
+            privateListingCreateOrderInput,
+          )
+
+          const order = await executeAllActions()
+
+          const recipientAddress = await privateListingRecipient.getAddress()
+          const counterOrder = constructPrivateListingCounterOrder(
+            order,
+            recipientAddress,
+          )
+          const fulfillments = getPrivateListingFulfillments(order)
+
+          // Regression: same falsy-0n bug exists in matchAdvancedOrders via
+          // the shared _validateMatchOrdersNativeValue helper.
+          expect(() =>
+            seaport.matchAdvancedOrders({
+              orders: [
+                { ...order, numerator: 1, denominator: 1, extraData: "0x" },
+                {
+                  ...counterOrder,
+                  numerator: 1,
+                  denominator: 1,
+                  extraData: "0x",
+                },
+              ],
+              fulfillments,
+              overrides: { value: 0n },
+              accountAddress: recipientAddress,
+            }),
+          ).not.to.throw()
+        })
       })
 
       describe("with ERC20", () => {

--- a/test/match-orders.spec.ts
+++ b/test/match-orders.spec.ts
@@ -183,15 +183,17 @@ describeWithFixture("As a user I want to match an order", fixture => {
           expect(() =>
             seaport.matchAdvancedOrders({
               orders: [
-                { ...order, numerator: 1, denominator: 1, extraData: "0x" },
+                { ...order, numerator: 1n, denominator: 1n, extraData: "0x" },
                 {
                   ...counterOrder,
-                  numerator: 1,
-                  denominator: 1,
+                  numerator: 1n,
+                  denominator: 1n,
                   extraData: "0x",
                 },
               ],
+              criteriaResolvers: [],
               fulfillments,
+              recipient: recipientAddress,
               overrides: { value: 0n },
               accountAddress: recipientAddress,
             }),


### PR DESCRIPTION
## Summary

Fixes #947

`_validateMatchOrdersNativeValue` used `!overrides?.value` to detect a missing ETH value. Since `BigInt(0)` (`0n`) is falsy in JavaScript, this check incorrectly throws when `overrides: { value: 0n }` is explicitly passed.

## Root cause

```ts
// Before:
if (hasNativeToken && !overrides?.value) {   // !0n === true  ← bug

// After:
if (hasNativeToken && overrides?.value == null) {  // true only for undefined/null
```

## Changes

- `src/seaport.ts`: one-line fix — `!overrides?.value` → `overrides?.value == null`
- `test/match-orders.spec.ts`: regression test verifying `value: 0n` does not throw