### PR TITLE
feat: expose built order components and an approvals-only executor

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -72,6 +72,7 @@ import {
 import {
   type ContractMethodReturnType,
   executeAllActions,
+  executeApprovals,
   getTransactionMethods,
   type TransactionMethods,
 } from "./utils/usecase"
@@ -200,6 +201,7 @@ export class Seaport {
 
     const createOrderAction = {
       type: "create",
+      orderComponents,
       getMessageToSign: () => {
         return this._getMessageToSign(orderComponents)
       },
@@ -219,6 +221,7 @@ export class Seaport {
       actions,
       executeAllActions: () =>
         executeAllActions(actions) as Promise<OrderWithCounter>,
+      executeApprovals: () => executeApprovals(actions),
     }
   }
 
@@ -274,6 +277,7 @@ export class Seaport {
 
     const createBulkOrdersAction = {
       type: "createBulk",
+      orderComponents: allOrderComponents,
       getMessageToSign: () => {
         return this._getBulkMessageToSign(allOrderComponents)
       },
@@ -289,6 +293,7 @@ export class Seaport {
       actions,
       executeAllActions: () =>
         executeAllActions(actions) as Promise<OrderWithCounter[]>,
+      executeApprovals: () => executeApprovals(actions),
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,12 +175,23 @@ export type ExchangeAction<T = unknown> = {
 
 export type CreateOrderAction = {
   type: "create"
+  /**
+   * The fully built order, ready to sign or to validate onchain. Reading this
+   * requests nothing from the wallet, unlike `createOrder()`.
+   */
+  orderComponents: OrderComponents
   getMessageToSign: () => Promise<string>
   createOrder: () => Promise<OrderWithCounter>
 }
 
 export type CreateBulkOrdersAction = {
   type: "createBulk"
+  /**
+   * The fully built orders, in input order, ready to sign or to validate
+   * onchain. Reading this requests nothing from the wallet, unlike
+   * `createBulkOrders()`.
+   */
+  orderComponents: OrderComponents[]
   getMessageToSign: () => Promise<string>
   createBulkOrders: () => Promise<OrderWithCounter[]>
 }
@@ -217,6 +228,12 @@ export type OrderUseCase<
         ? OrderWithCounter[]
         : ContractTransaction
   >
+  /**
+   * Performs the approval transactions only, skipping the final action. Use
+   * with a create action's `orderComponents` to build an order the offerer
+   * approves onchain rather than by signature.
+   */
+  executeApprovals: () => Promise<void>
 }
 
 export type FulfillmentComponent = {

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -52,6 +52,7 @@ import {
 import {
   type ContractMethodReturnType,
   executeAllActions,
+  executeApprovals,
   getTransactionMethods,
 } from "./usecase"
 
@@ -313,6 +314,7 @@ export function fulfillBasicOrder(
     actions,
     executeAllActions: () =>
       executeAllActions(actions) as Promise<ContractTransaction>,
+    executeApprovals: () => executeApprovals(actions),
   }
 }
 
@@ -503,6 +505,7 @@ export function fulfillStandardOrder(
     actions,
     executeAllActions: () =>
       executeAllActions(actions) as Promise<ContractTransaction>,
+    executeApprovals: () => executeApprovals(actions),
   }
 }
 
@@ -791,6 +794,7 @@ export function fulfillAvailableOrders({
     actions,
     executeAllActions: () =>
       executeAllActions(actions) as Promise<ContractTransaction>,
+    executeApprovals: () => executeApprovals(actions),
   }
 }
 

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -18,7 +18,21 @@ import type {
   OrderUseCase,
 } from "../types"
 
-export const executeAllActions = async <
+/**
+ * Sends every approval transaction in a use case and waits for its receipt,
+ * without performing the use case's final action.
+ *
+ * Useful when the offerer approves an order onchain instead of by signature,
+ * for example through Seaport's `validate()`. A smart contract account may not
+ * be able to produce an offchain signature at all, so requesting one in order
+ * to build the order is a hard blocker rather than just a wasted prompt. Pair
+ * this with the create action's `orderComponents` to get a ready-to-validate
+ * order without any signature request.
+ *
+ * Approvals run sequentially because they are transactions from a single
+ * account and take consecutive nonces.
+ */
+export const executeApprovals = async <
   T extends CreateOrderAction | CreateBulkOrdersAction | ExchangeAction,
 >(
   actions: OrderUseCase<T>["actions"],
@@ -30,6 +44,14 @@ export const executeAllActions = async <
       await tx.wait()
     }
   }
+}
+
+export const executeAllActions = async <
+  T extends CreateOrderAction | CreateBulkOrdersAction | ExchangeAction,
+>(
+  actions: OrderUseCase<T>["actions"],
+) => {
+  await executeApprovals(actions)
 
   const finalAction = actions[actions.length - 1] as T
 

--- a/test/execute-approvals.spec.ts
+++ b/test/execute-approvals.spec.ts
@@ -1,0 +1,189 @@
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType, MAX_INT } from "../src/constants"
+import type {
+  ApprovalAction,
+  CreateBulkOrdersAction,
+  CreateOrderAction,
+} from "../src/types"
+import { generateRandomSalt } from "../src/utils/order"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a user I want to approve an order onchain instead of signing it",
+  fixture => {
+    it("exposes the built order components without requesting a signature", async () => {
+      const { seaport, testErc721, ethers } = fixture
+
+      const [offerer, zone] = await ethers.getSigners()
+      const nftId = "1"
+      await testErc721.mint(await offerer.getAddress(), nftId)
+      const salt = generateRandomSalt()
+
+      const useCase = await seaport.createOrder({
+        startTime: "0",
+        endTime: MAX_INT.toString(),
+        salt,
+        offer: [
+          {
+            itemType: ItemType.ERC721,
+            token: await testErc721.getAddress(),
+            identifier: nftId,
+          },
+        ],
+        consideration: [
+          {
+            amount: parseEther("10").toString(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+        fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+      })
+
+      const createOrderAction = useCase.actions[
+        useCase.actions.length - 1
+      ] as CreateOrderAction
+
+      // The exposed components must be the same order signOrder would sign.
+      const signed = await createOrderAction.createOrder()
+      expect(createOrderAction.orderComponents).to.deep.equal(signed.parameters)
+    })
+
+    it("runs approvals without performing the final action", async () => {
+      const { seaportContract, seaport, testErc721, ethers } = fixture
+
+      const [offerer] = await ethers.getSigners()
+      const nftId = "1"
+      await testErc721.mint(await offerer.getAddress(), nftId)
+
+      const useCase = await seaport.createOrder({
+        startTime: "0",
+        endTime: MAX_INT.toString(),
+        salt: generateRandomSalt(),
+        offer: [
+          {
+            itemType: ItemType.ERC721,
+            token: await testErc721.getAddress(),
+            identifier: nftId,
+          },
+        ],
+        consideration: [
+          {
+            amount: parseEther("10").toString(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+      })
+
+      const approvalAction = useCase.actions[0] as ApprovalAction
+      expect(approvalAction.type).to.equal("approval")
+      expect(
+        await testErc721.isApprovedForAll(
+          await offerer.getAddress(),
+          await seaportContract.getAddress(),
+        ),
+      ).to.be.false
+
+      await useCase.executeApprovals()
+
+      expect(
+        await testErc721.isApprovedForAll(
+          await offerer.getAddress(),
+          await seaportContract.getAddress(),
+        ),
+      ).to.be.true
+    })
+
+    it("validates the order onchain from the exposed components", async () => {
+      const { seaport, testErc721, ethers } = fixture
+
+      const [offerer] = await ethers.getSigners()
+      const nftId = "1"
+      await testErc721.mint(await offerer.getAddress(), nftId)
+
+      const useCase = await seaport.createOrder({
+        startTime: "0",
+        endTime: MAX_INT.toString(),
+        salt: generateRandomSalt(),
+        offer: [
+          {
+            itemType: ItemType.ERC721,
+            token: await testErc721.getAddress(),
+            identifier: nftId,
+          },
+        ],
+        consideration: [
+          {
+            amount: parseEther("10").toString(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+      })
+
+      await useCase.executeApprovals()
+
+      const { orderComponents } = useCase.actions[
+        useCase.actions.length - 1
+      ] as CreateOrderAction
+
+      const orderHash = seaport.getOrderHash(orderComponents)
+      expect((await seaport.getOrderStatus(orderHash)).isValidated).to.be.false
+
+      // An empty signature is what makes this worth having: Seaport takes the
+      // offerer sending the transaction as proof they approved the order.
+      const transaction = await seaport
+        .validate(
+          [{ parameters: orderComponents, signature: "0x" }],
+          await offerer.getAddress(),
+        )
+        .transact()
+      await transaction.wait()
+
+      expect((await seaport.getOrderStatus(orderHash)).isValidated).to.be.true
+    })
+
+    it("exposes components for every order in a bulk use case, in input order", async () => {
+      const { seaport, testErc721, ethers } = fixture
+
+      const [offerer] = await ethers.getSigners()
+      await testErc721.mint(await offerer.getAddress(), "1")
+      await testErc721.mint(await offerer.getAddress(), "2")
+
+      const inputs = ["1", "2"].map(identifier => ({
+        startTime: "0",
+        endTime: MAX_INT.toString(),
+        salt: generateRandomSalt(),
+        offer: [
+          {
+            itemType: ItemType.ERC721 as const,
+            token: testErc721.target as string,
+            identifier,
+          },
+        ],
+        consideration: [
+          {
+            amount: parseEther("10").toString(),
+            recipient: offerer.address,
+          },
+        ],
+      }))
+
+      const useCase = await seaport.createBulkOrders(inputs)
+      const bulkAction = useCase.actions[
+        useCase.actions.length - 1
+      ] as CreateBulkOrdersAction
+
+      expect(bulkAction.orderComponents).to.have.lengthOf(2)
+      expect(
+        bulkAction.orderComponents.map(
+          components => components.offer[0].identifierOrCriteria,
+        ),
+      ).to.deep.equal(["1", "2"])
+
+      const signed = await bulkAction.createBulkOrders()
+      expect(bulkAction.orderComponents).to.deep.equal(
+        signed.map(order => order.parameters),
+      )
+    })
+  },
+)


### PR DESCRIPTION
## Motivation

`createOrder` and `createBulkOrders` build the complete order in `_formatOrder`, then expose it only through `createOrder()` / `createBulkOrders()`, both of which request an EIP-712 signature. There is no supported way to obtain the built order without signing it.

That blocks approving an order onchain. Seaport's `validate()` accepts an order with an empty signature, taking the transaction sender as proof the offerer approved it, which is the intended path for an offerer that cannot produce an offchain signature. A smart contract account often cannot, so requiring a signature to *build* the order is a hard blocker for that flow, not just a wasted prompt.

The only workaround today is to read the components back out of the `getMessageToSign()` payload. We did exactly that in the OpenSea SDK, and it is unpleasant: Seaport's EIP-712 `OrderComponents` type omits `totalOriginalConsiderationItems`, so it has to be reconstructed from the consideration array, and `TypedDataEncoder.getPayload` renders every uint as a decimal string, so `orderType` and each `itemType` have to be coerced back to numbers and a hex `salt` comes out as decimal. All recoverable, none of it something a consumer should be doing.

## What this adds

Both additive, no existing behavior changes.

**`orderComponents` on the create actions.** `CreateOrderAction.orderComponents` is the `OrderComponents` object `_formatOrder` produced. `CreateBulkOrdersAction.orderComponents` is the array, in input order. Reading either requests nothing from the wallet.

**`executeApprovals()` on `OrderUseCase`.** Sends each approval transaction and waits for its receipt, then stops, skipping the final create/exchange action. `executeAllActions` now delegates its approval loop to it, so the two cannot drift.

Together:

```ts
const useCase = await seaport.createOrder(input, offerer)
await useCase.executeApprovals()

const { orderComponents } = useCase.actions.at(-1) as CreateOrderAction
await seaport.validate([{ parameters: orderComponents, signature: "0x" }], offerer).transact()
```

`OrderUseCase` is shared with fulfillment, so the three use cases in `utils/fulfill.ts` gain `executeApprovals` too. It is meaningful there as well: approve the tokens a fulfillment needs without submitting the fulfillment.

Approvals stay sequential. They are transactions from one account taking consecutive nonces, so they cannot be sent concurrently.

## Compatibility

Additive on the way out, so existing consumers are unaffected: new properties on returned objects, no signature or behavior changes to existing methods.

One note for anyone implementing `OrderUseCase` themselves rather than consuming it: `executeApprovals` is a required property on the type, so a hand-built use case object will now fail to typecheck until it adds one. Everything inside this repo that constructs an `OrderUseCase` is updated here. Making it optional would avoid that at the cost of every consumer having to null-check it, which seemed the worse trade for a type that is essentially always produced by this library.

## Testing

`npx hardhat test` — 142 passing, up from 138.

New `test/execute-approvals.spec.ts` runs against the real Seaport contract via the existing fixture, no mocks:

- `orderComponents` deep-equals `(await createOrderAction.createOrder()).parameters`, so the exposed object is provably the same order that would be signed
- `executeApprovals()` sets the ERC-721 operator approval and does not produce an order
- end to end: `executeApprovals()`, then `validate()` with `signature: "0x"`, then `getOrderStatus(getOrderHash(orderComponents)).isValidated` flips from false to true. This is the flow the whole change exists for, proven onchain.
- bulk: components for every order, in input order, deep-equal to what `createBulkOrders()` signs

## Follow-up

Once this is released, the OpenSea SDK drops its payload-parsing helper (ProjectOpenSea/opensea-devtools#609) in favor of `executeApprovals()` + `orderComponents`, removing the reconstruction and coercion described above.
