### PR TITLE
fix: do not mutate caller's CreateOrderInput in createBulkOrders

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -245,12 +245,12 @@ export class Seaport {
     const allOrderComponents: OrderComponents[] = []
 
     for (const input of createOrderInput) {
-      input.counter ??= offererCounter
+      const orderInput = { ...input, counter: input.counter ?? offererCounter }
       const { orderComponents, approvalActions } = await this._formatOrder(
         signer,
         offerer,
         Boolean(exactApproval),
-        input,
+        orderInput,
       )
 
       allOrderComponents.push(orderComponents)

--- a/test/create-bulk-orders.spec.ts
+++ b/test/create-bulk-orders.spec.ts
@@ -188,5 +188,39 @@ describeWithFixture(
         conduitOperator,
       ])
     })
+
+  it("does not mutate caller's CreateOrderInput objects", async () => {
+    const { seaport, testErc721, ethers } = fixture
+
+    const [offerer, zone] = await ethers.getSigners()
+
+    await testErc721.mint(await offerer.getAddress(), "1")
+
+    const input = {
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: await testErc721.getAddress(),
+          identifier: "1",
+        },
+      ],
+      consideration: [
+        {
+          amount: parseEther("1").toString(),
+          recipient: await offerer.getAddress(),
+        },
+      ],
+      fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+    }
+
+    // counter is intentionally absent — caller did not set it
+    expect((input as Record<string, unknown>).counter).to.be.undefined
+
+    await seaport.createBulkOrders([input], await offerer.getAddress())
+
+    // Regression: input.counter ??= offererCounter mutated the caller's object.
+    // After the fix (spread copy), the original must remain untouched.
+    expect((input as Record<string, unknown>).counter).to.be.undefined
+  })
   },
 )


### PR DESCRIPTION
## Summary

Fixes #949

`createBulkOrders` used `input.counter ??= offererCounter` inside a for-loop, which writes the resolved counter value back to the caller's original object.
Callers who inspect or reuse the same `CreateOrderInput` after the call see a `counter` value they never set.

## Root cause

```ts
// Before:
for (const input of createOrderInput) {
  input.counter ??= offererCounter  // ← mutates caller's object
```

`input` is a direct reference into the caller-supplied array. `??=` assigns when the left side is `null` or `undefined`, so the caller's object is permanently modified on every call.

## Fix

```ts
// After:
const orderInput = { ...input, counter: input.counter ?? offererCounter }
```

Spread into a local copy the original object is never touched.

## Changes

- `src/seaport.ts`: 2-line change (remove `??=`, add spread)
- `test/create-bulk-orders.spec.ts`: regression test asserting `counter` 
  remains `undefined` on the caller's object after `createBulkOrders` returns