### PR TITLE
fix: report approval tokens in the order's casing, not the summation key

### DIFF
--- a/src/utils/balanceAndApprovalCheck.ts
+++ b/src/utils/balanceAndApprovalCheck.ts
@@ -160,7 +160,14 @@ export const getInsufficientBalanceAndApprovalAmounts = ({
         )
 
         return {
-          token,
+          // Report the address as the order carried it, not as the summation
+          // keyed it. `token` here is a key from getSummedTokenAndIdentifierAmounts,
+          // which lowercases so that two casings of one address sum into a
+          // single bucket. That key is an internal grouping detail; it reaches
+          // callers through InsufficientApprovals -> ApprovalAction.token, so
+          // using it here silently lowercased every approval action's token and
+          // broke consumers comparing against a checksummed address.
+          token: balanceAndApproval.token,
           identifierOrCriteria,
           requiredAmount: amount,
           amountHave: balanceAndApproval[filterKey],


### PR DESCRIPTION
`main` is red. This fixes it.

## What happened

#944 and #935 are both correct on their own and break when combined. After both landed, the exactApproval regression test from #935 finds **zero** ERC721 approval actions instead of two:

```
AssertionError: expected +0 to equal 2
  at test/fulfill-orders.spec.ts:1221
```

#944 lowercases the accumulator key in `getSummedTokenAndIdentifierAmounts` so that two casings of the same address sum into one bucket. That part is right and stays.

The problem is where that key ends up. `filterBalancesOrApprovals` destructures it and puts it straight into the record it returns:

```ts
.map(([token, identifierOrCriteria, amount]) => {
  ...
  return { token, ... }   // <- lowercased map key, not the order's address
})
```

That record becomes `InsufficientApprovals`, which becomes `ApprovalAction.token`. So every approval action handed to a caller silently switched to lowercase, and anything comparing it against a checksummed address stopped matching. The #935 test compares against `await testErc721.getAddress()`, which is checksummed, so its filter matched nothing.

## The fix

Read the address from the `balancesAndApprovals` record, which carries the casing the order supplied. The lowercased key stays an internal grouping detail of the summation, which is all it was meant to be.

## Impact beyond the test

This is a public API shape change, not just a broken test. `ApprovalAction.token` is part of what `createOrder`, `createBulkOrders`, and the `fulfill*` methods return. Any consumer doing `action.token === someChecksummedAddress` would have broken on the next release. It's worth stating plainly that I reviewed #944 and missed this: I checked `findBalanceAndApproval` (case-insensitive on both sides, fine) and the `ethers.ZeroAddress` readers (no letters, fine), but not that the map keys are destructured back out into the returned approval records.

## No new test

#935's test is exactly the right coverage and it does fail without this change. It is what caught the regression. Adding a second assertion for the same seam would be redundant.

Neither existing test covered the seam on its own: #944's asserts on the summed map, and #935's predated the lowercasing.

## Verification

- `npm test`: 157 passing, 0 failing (was 156 passing / 1 failing on `main`)
- `npm run lint`: clean, `check-types` and Biome across 56 files