### PR TITLE
fix: do not mutate the caller's CreateOrderInput in createBulkOrders

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -248,12 +248,12 @@ export class Seaport {
     const allOrderComponents: OrderComponents[] = []
 
     for (const input of createOrderInput) {
-      input.counter ??= offererCounter
+      const orderInput = { ...input, counter: input.counter ?? offererCounter }
       const { orderComponents, approvalActions } = await this._formatOrder(
         signer,
         offerer,
         Boolean(exactApproval),
-        input,
+        orderInput,
       )
 
       allOrderComponents.push(orderComponents)

--- a/test/create-bulk-orders.spec.ts
+++ b/test/create-bulk-orders.spec.ts
@@ -188,5 +188,39 @@ describeWithFixture(
         conduitOperator,
       ])
     })
+
+  it("does not mutate caller's CreateOrderInput objects", async () => {
+    const { seaport, testErc721, ethers } = fixture
+
+    const [offerer, zone] = await ethers.getSigners()
+
+    await testErc721.mint(await offerer.getAddress(), "1")
+
+    const input = {
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: await testErc721.getAddress(),
+          identifier: "1",
+        },
+      ],
+      consideration: [
+        {
+          amount: parseEther("1").toString(),
+          recipient: await offerer.getAddress(),
+        },
+      ],
+      fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+    }
+
+    // counter is intentionally absent — caller did not set it
+    expect((input as Record<string, unknown>).counter).to.be.undefined
+
+    await seaport.createBulkOrders([input], await offerer.getAddress())
+
+    // Regression: input.counter ??= offererCounter mutated the caller's object.
+    // After the fix (spread copy), the original must remain untouched.
+    expect((input as Record<string, unknown>).counter).to.be.undefined
+  })
   },
 )

--- a/test/create-bulk-orders.spec.ts
+++ b/test/create-bulk-orders.spec.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalAction,
   BasicErc721Item,
   CreateBulkOrdersAction,
+  CreateOrderInput,
 } from "../src/types"
 import { getApprovalActions } from "../src/utils/approval"
 import { generateRandomSalt } from "../src/utils/order"
@@ -189,38 +190,38 @@ describeWithFixture(
       ])
     })
 
-  it("does not mutate caller's CreateOrderInput objects", async () => {
-    const { seaport, testErc721, ethers } = fixture
+    it("does not mutate caller's CreateOrderInput objects", async () => {
+      const { seaport, testErc721, ethers } = fixture
 
-    const [offerer, zone] = await ethers.getSigners()
+      const [offerer, zone] = await ethers.getSigners()
 
-    await testErc721.mint(await offerer.getAddress(), "1")
+      await testErc721.mint(await offerer.getAddress(), "1")
 
-    const input = {
-      offer: [
-        {
-          itemType: ItemType.ERC721,
-          token: await testErc721.getAddress(),
-          identifier: "1",
-        },
-      ],
-      consideration: [
-        {
-          amount: parseEther("1").toString(),
-          recipient: await offerer.getAddress(),
-        },
-      ],
-      fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
-    }
+      const input: CreateOrderInput = {
+        offer: [
+          {
+            itemType: ItemType.ERC721,
+            token: await testErc721.getAddress(),
+            identifier: "1",
+          },
+        ],
+        consideration: [
+          {
+            amount: parseEther("1").toString(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+        fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+      }
 
-    // counter is intentionally absent — caller did not set it
-    expect((input as Record<string, unknown>).counter).to.be.undefined
+      // counter is intentionally absent — caller did not set it
+      expect(input.counter).to.be.undefined
 
-    await seaport.createBulkOrders([input], await offerer.getAddress())
+      await seaport.createBulkOrders([input], await offerer.getAddress())
 
-    // Regression: input.counter ??= offererCounter mutated the caller's object.
-    // After the fix (spread copy), the original must remain untouched.
-    expect((input as Record<string, unknown>).counter).to.be.undefined
-  })
+      // Regression: input.counter ??= offererCounter mutated the caller's object.
+      // After the fix (spread copy), the original must remain untouched.
+      expect(input.counter).to.be.undefined
+    })
   },
 )


### PR DESCRIPTION
Supersedes #951 by @Sertug17, whose commit is preserved here as the first of the two. Fixes #949. Opened on a branch in this repo because the fork branch could not be pushed to directly; the fix and the credit are theirs.

## The bug

`createBulkOrders` wrote the resolved counter back into the caller's own object:

```ts
for (const input of createOrderInput) {
  input.counter ??= offererCounter   // input is a reference into the caller's array
```

`??=` assigns whenever the left side is nullish, so any caller that inspected or reused the same `CreateOrderInput` afterwards saw a `counter` it never set. Confirmed against current `main`.

The fix spreads into a local copy, so the caller's object is never touched:

```ts
const orderInput = { ...input, counter: input.counter ?? offererCounter }
```

## What I added on top

The submitted test didn't compile, and `lint` is a required check, so it couldn't merge as-is:

```
test/create-bulk-orders.spec.ts(219,37): error TS2322: Type '{ offer: ...; consideration: ...; fees: ... }'
  is not assignable to type 'CreateOrderInput'
```

TypeScript widened `itemType` and the item shapes rather than inferring the `CreateOrderInput` union member. Annotating the variable fixes it, and that in turn let both `as Record<string, unknown>` casts go, since `counter` is a real optional property on the type:

```ts
const input: CreateOrderInput = { ... }
expect(input.counter).to.be.undefined
```

Also ran Biome, since the new `it` block was indented short of the surrounding `describe` body, and rebased onto current `main` (the branch was 9 commits behind and `src/seaport.ts` had moved under it via #946, #948 and #950).

## Verification

- `npm run lint`: clean, `check-types` and Biome across 56 files
- `npm test`: 158 passing, 0 failing
- The test is a real tripwire: it asserts `input.counter` is still `undefined` after the call, which is exactly what the `??=` broke

Co-authored-by: Sertug17 <104278804+Sertug17@users.noreply.github.com>