### PR TITLE
fix: freeze exposed orderComponents, release as 4.2.0 not 4.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.1.8",
+  "version": "4.2.0",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -65,6 +65,7 @@ import {
   areAllCurrenciesSame,
   deductFees,
   feeToConsiderationItem,
+  freezeOrderComponents,
   generateRandomSalt,
   mapInputItemToOfferItem,
   totalItemsAmount,
@@ -192,12 +193,12 @@ export class Seaport {
     const signer = await this._getSigner(accountAddress)
     const offerer = accountAddress ?? (await signer.getAddress())
 
-    const { orderComponents, approvalActions } = await this._formatOrder(
-      signer,
-      offerer,
-      Boolean(exactApproval),
-      input,
-    )
+    const { orderComponents: builtComponents, approvalActions } =
+      await this._formatOrder(signer, offerer, Boolean(exactApproval), input)
+
+    // Frozen because this same object is both exposed on the action and signed
+    // below; see freezeOrderComponents.
+    const orderComponents = freezeOrderComponents(builtComponents)
 
     const createOrderAction = {
       type: "create",
@@ -256,7 +257,9 @@ export class Seaport {
         orderInput,
       )
 
-      allOrderComponents.push(orderComponents)
+      // Frozen because these same objects are both exposed on the action and
+      // signed below; see freezeOrderComponents.
+      allOrderComponents.push(freezeOrderComponents(orderComponents))
 
       // Dedupe approvals by token and operator (and identifier for exact ERC721)
       const seenApprovalKeys = new Set(
@@ -274,6 +277,10 @@ export class Seaport {
         }
       }
     }
+
+    // The array itself too, so a caller cannot reorder or drop an order after
+    // reading it; the signature covers the batch in this exact order.
+    Object.freeze(allOrderComponents)
 
     const createBulkOrdersAction = {
       type: "createBulk",

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -15,6 +15,7 @@ import type {
   Item,
   OfferItem,
   Order,
+  OrderComponents,
   OrderParameters,
 } from "../types"
 import { getMaximumSizeForOrder, isCurrencyItem } from "./item"
@@ -22,6 +23,38 @@ import { MerkleTree } from "./merkletree"
 
 const multiplyBasisPoints = (amount: BigNumberish, basisPoints: BigNumberish) =>
   (BigInt(amount) * BigInt(basisPoints)) / ONE_HUNDRED_PERCENT_BP
+
+const deepFreeze = <T>(value: T): T => {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) {
+    return value
+  }
+
+  for (const key of Object.keys(value)) {
+    deepFreeze((value as Record<string, unknown>)[key])
+  }
+
+  return Object.freeze(value)
+}
+
+/**
+ * Freezes an order's components before they are handed to a caller.
+ *
+ * `createOrder` and `createBulkOrders` expose the built `orderComponents` on
+ * their create action, and the same object is what `getMessageToSign()` and
+ * `createOrder()` sign. Without this, a caller could read the components,
+ * mutate them, and then sign terms that differ from the ones the SDK built and
+ * validated -- and in an app where one layer inspects the order and another
+ * signs it, those two layers would disagree silently.
+ *
+ * Freezing rather than copying keeps a single object, so a mutation attempt
+ * fails loudly under ESM's strict mode instead of being quietly dropped on a
+ * clone the signer never sees. Every consumer of these components (`signOrder`,
+ * `signBulkOrder`, `_getMessageToSign`, `getBulkOrderTree`) only reads them, and
+ * `getBulkOrderTree` copies before padding, so nothing needs them mutable.
+ */
+export const freezeOrderComponents = <T extends OrderComponents>(
+  orderComponents: T,
+): T => deepFreeze(orderComponents)
 
 export const feeToConsiderationItem = ({
   fee,

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -31,6 +31,12 @@ import type {
  *
  * Approvals run sequentially because they are transactions from a single
  * account and take consecutive nonces.
+ *
+ * Note that this grants the approvals and then stops, so abandoning the flow
+ * afterwards leaves them standing with no order behind them. With the default
+ * `exactApproval: false` an ERC721/ERC1155 approval is `setApprovalForAll`,
+ * which is collection-wide. Callers who may not go on to create or fulfill
+ * should prefer `exactApproval: true`, or revoke afterwards.
  */
 export const executeApprovals = async <
   T extends CreateOrderAction | CreateBulkOrdersAction | ExchangeAction,

--- a/test/create-order.spec.ts
+++ b/test/create-order.spec.ts
@@ -930,6 +930,79 @@ describeWithFixture("As a user I want to create an order", fixture => {
     expect(order.parameters.zone).eq(zone)
     expect(order.parameters.zoneHash).eq(zoneHash)
   })
+
+  describe("exposed orderComponents", () => {
+    const nftId = "1"
+
+    const orderInput = async () => {
+      const { testErc721, ethers } = fixture
+      const [offerer] = await ethers.getSigners()
+
+      await testErc721.mint(await offerer.getAddress(), nftId)
+
+      const input: CreateOrderInput = {
+        offer: [
+          {
+            itemType: ItemType.ERC721,
+            token: await testErc721.getAddress(),
+            identifier: nftId,
+          },
+        ],
+        consideration: [
+          {
+            amount: parseEther("10").toString(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+      }
+
+      return { offerer, input }
+    }
+
+    it("cannot be mutated to change what gets signed", async () => {
+      const { seaport } = fixture
+      const { input } = await orderInput()
+
+      const { actions } = await seaport.createOrder(input)
+      const createAction = actions[actions.length - 1]
+      if (createAction.type !== "create") throw new Error("expected create")
+
+      const { orderComponents } = createAction
+
+      // The exposed object is the one that gets signed, so a caller must not be
+      // able to read it, change the terms, and then sign the changed terms.
+      expect(Object.isFrozen(orderComponents)).to.be.true
+      expect(Object.isFrozen(orderComponents.consideration)).to.be.true
+      expect(Object.isFrozen(orderComponents.consideration[0])).to.be.true
+      expect(Object.isFrozen(orderComponents.offer[0])).to.be.true
+
+      const attacker = "0x000000000000000000000000000000000000dEaD"
+      expect(() => {
+        ;(orderComponents.consideration[0] as { recipient: string }).recipient =
+          attacker
+      }).to.throw()
+      expect(orderComponents.consideration[0].recipient).to.not.equal(attacker)
+    })
+
+    it("still signs and hashes correctly once frozen", async () => {
+      const { seaport } = fixture
+      const { input } = await orderInput()
+
+      const { actions, executeAllActions } = await seaport.createOrder(input)
+      const createAction = actions[actions.length - 1]
+      if (createAction.type !== "create") throw new Error("expected create")
+
+      // Freezing must not break any consumer of the components: the EIP-712
+      // payload, the signature, and the order hash all read the same object.
+      const payload = await createAction.getMessageToSign()
+      expect(JSON.parse(payload).message.offerer).to.be.a("string")
+
+      const order = await executeAllActions()
+      expect(order.signature).to.be.a("string")
+      expect(seaport.getOrderHash(order.parameters)).to.be.a("string")
+      expect(order.parameters).to.deep.equal(createAction.orderComponents)
+    })
+  })
 })
 
 describeWithFixture(


### PR DESCRIPTION
Pre-publish hardening from the security review of 4.1.8. No blocking vulnerability was found; every asset-flow change in this release moves risk in the safe direction. These are the three things worth fixing before it goes out.

## 1. Freeze the order components exposed by #950

#950 exposes the built `orderComponents` on the create action, and it is the same object the action signs:

```ts
const createOrderAction = {
  orderComponents,                                   // handed to the caller
  createOrder: async () => {
    const signature = await this.signOrder(orderComponents, offerer)   // same object
```

A caller can read it, change the terms, and then sign the changed terms. Nobody attacks themselves with that. It matters where one layer inspects the order and another signs it, because the two layers would disagree with nothing to catch it. It is the exact mirror of #953, which stopped the SDK mutating the caller's input; this is the caller mutating the SDK's.

Frozen rather than copied, deliberately. One object means a mutation attempt fails loudly under ESM strict mode, instead of being silently dropped on a clone the signer never reads. A copy would make `action.orderComponents` and the signed `parameters` two objects with equal contents, which is its own trap.

Verified nothing needs them mutable: `signOrder`, `signBulkOrder` and `_getMessageToSign` only read them, and `getBulkOrderTree` does `[...orderComponents]` before `fillArray` pads, so the padding never touches the caller's array. The bulk array is frozen too, so an order cannot be reordered or dropped after being read, since the signature covers the batch in that exact order.

## 2. 4.1.8 should be 4.2.0

#950 added members to `CreateOrderAction`, `CreateBulkOrdersAction` and `OrderUseCase` as **required**, not optional:

```ts
orderComponents: OrderComponents        // CreateOrderAction
executeApprovals: () => Promise<void>   // OrderUseCase
```

Anyone constructing those types themselves, which in practice means test mocks, fails to compile on an upgrade that a patch version implies is safe. #940 also turns an input that previously returned into a throw. Neither belongs in a patch.

## 3. Document what executeApprovals leaves behind

It grants the approvals and stops, so abandoning the flow afterwards leaves them standing with no order behind them. With the default `exactApproval: false` an NFT approval is `setApprovalForAll`, which is collection-wide. Same exposure as any mid-way failure of `executeAllActions` today, but this makes it a first-class flow, so it deserves a line. Doc only.

## Testing

- `npm test`: 160 passing, 0 failing
- `npm run lint`: clean, `check-types` and Biome across 56 files
- The freeze test is a real tripwire: with `freezeOrderComponents` removed it fails with `expected false to be true`
- The second test is the one that matters for regressions: it asserts the EIP-712 payload, the signature, and the order hash all still work through the frozen object, so freezing cannot quietly break signing

## Rest of the security review, for the record

No findings that block the release.

`#944` + `#952` make the balance check stricter, not looser: merging address casings can only raise a required amount. `#935`'s dedup key is strictly more granular, so it retains more approvals and never widens one. `#946` only ever falls back to the standard route more often; I checked the one case that could have gone the other way (a tip making rule 8's `.every()` false and skipping that guard) and rule 5 or rule 4 rejects those first. I also confirmed `shouldUseBasicFulfill` and `fulfillBasicOrder` both build `[...consideration, ...tips]`, so the set validated is exactly the set paid, in the same order. `#945` changes no production signature, since `getBulkOrderHash` still has zero callers and real bulk signing goes through `getBulkOrderTree`. `#948` only relaxes an advisory client-side guard on a method that already documents it performs no balance or approval checks.

Dependencies: the advisories GitHub reports are dev-only. Runtime deps are `ethers` and `merkletreejs`, `npm audit --omit=dev` reports 0, and only `lib` and `src` are published.