### PR TITLE
test: stop chain time drifting behind wall clock in the fixture

### DIFF
--- a/test/utils/chain-time.spec.ts
+++ b/test/utils/chain-time.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from "chai"
+import type { ChainTimeProvider } from "./setup"
+import { syncChainTimeToWallClock } from "./setup"
+
+// Guards the fixture's clock sync. The bug it prevents is not visible in a fast
+// run: the simulated chain advances one second per mined block, so over a slow
+// suite chain time falls behind wall clock, and orders created with the default
+// `startTime` (wall clock) land in the chain's future and get skipped as not yet
+// active. Asserting on the drift directly keeps that logic honest without
+// needing a slow suite to expose it.
+describe("syncChainTimeToWallClock", () => {
+  const stubProvider = (blockTimestamp: number | null) => {
+    const calls: { method: string; params: unknown[] }[] = []
+
+    const provider: ChainTimeProvider = {
+      provider: {
+        getBlock: async () =>
+          blockTimestamp === null ? null : { timestamp: blockTimestamp },
+        send: async (method: string, params: unknown[]) => {
+          calls.push({ method, params })
+          return null
+        },
+      },
+    }
+
+    return { provider, calls }
+  }
+
+  it("jumps the chain forward when it has drifted behind wall clock", async () => {
+    const { provider, calls } = stubProvider(1_000)
+
+    const advanced = await syncChainTimeToWallClock(provider, 1_060)
+
+    expect(advanced).to.be.true
+    expect(calls.map(call => call.method)).to.deep.equal([
+      "evm_setNextBlockTimestamp",
+      "evm_mine",
+    ])
+    expect(calls[0].params).to.deep.equal([1_060])
+  })
+
+  it("does nothing when the chain is already ahead", async () => {
+    // Mining blocks pushes chain time past wall clock, which is the normal case
+    // in a fast run. evm_setNextBlockTimestamp would reject a timestamp at or
+    // behind the current block, so this has to be a no-op rather than a clamp.
+    const { provider, calls } = stubProvider(1_100)
+
+    expect(await syncChainTimeToWallClock(provider, 1_060)).to.be.false
+    expect(calls).to.be.empty
+  })
+
+  it("does nothing when the chain is exactly at wall clock", async () => {
+    const { provider, calls } = stubProvider(1_060)
+
+    expect(await syncChainTimeToWallClock(provider, 1_060)).to.be.false
+    expect(calls).to.be.empty
+  })
+
+  it("does nothing when there is no block to read", async () => {
+    const { provider, calls } = stubProvider(null)
+
+    expect(await syncChainTimeToWallClock(provider, 1_060)).to.be.false
+    expect(calls).to.be.empty
+  })
+})

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -28,6 +28,52 @@ type Fixture = {
   ethers: HardhatEthers
 }
 
+/**
+ * Pulls the chain's clock forward to wall-clock time.
+ *
+ * The simulated chain only advances its timestamp when a block is mined, one
+ * second per block, so chain time tracks *blocks mined*, not elapsed real time.
+ * Wall clock keeps running regardless. Over a suite that mines few blocks but
+ * takes a long time, chain time falls behind real time, and it never catches up
+ * on its own because the network is not recreated between tests.
+ *
+ * That matters because `createOrder` defaults `startTime` to
+ * `Math.floor(Date.now() / 1000)`, which is wall clock. Once the drift exceeds
+ * the blocks a test mines, every order it creates has a `startTime` in the
+ * chain's future, Seaport skips them all as not yet active, and a multi-order
+ * fulfillment reverts with `NoSpecifiedOrdersAvailable()`.
+ *
+ * The failure is timing-dependent rather than deterministic, which is why it
+ * showed up only under `npm run coverage` (roughly 3x slower) and only
+ * intermittently: it needs total suite wall time to outrun total blocks mined.
+ *
+ * Only ever moves the clock forward. When a test has mined enough blocks to put
+ * chain time ahead of wall clock, this is a no-op, and
+ * `evm_setNextBlockTimestamp` rejects a timestamp at or behind the current
+ * block anyway.
+ */
+export type ChainTimeProvider = {
+  provider: {
+    getBlock: (tag: string) => Promise<{ timestamp: number } | null>
+    send: (method: string, params: unknown[]) => Promise<unknown>
+  }
+}
+
+export const syncChainTimeToWallClock = async (
+  ethers: ChainTimeProvider,
+  nowSeconds = Math.floor(Date.now() / 1000),
+) => {
+  const latest = await ethers.provider.getBlock("latest")
+
+  if (!latest || latest.timestamp >= nowSeconds) {
+    return false
+  }
+
+  await ethers.provider.send("evm_setNextBlockTimestamp", [nowSeconds])
+  await ethers.provider.send("evm_mine", [])
+  return true
+}
+
 export const describeWithFixture = (
   name: string,
   suiteCb: (fixture: Fixture) => unknown,
@@ -105,6 +151,8 @@ export const describeWithFixture = (
       fixture.testErc20USDC = testErc20USDC
       fixture.testERC1271Wallet = testERC1271Wallet
       fixture.ethers = ethers
+
+      await syncChainTimeToWallClock(ethers)
     })
 
     suiteCb(fixture as Fixture)


### PR DESCRIPTION
Fixes the intermittent `NoSpecifiedOrdersAvailable()` failures that appeared under `npm run coverage` but not `npm test`, most recently on #955 (coverage failed, re-run passed) and on `main` at `ba230999`, where one workflow run failed and another succeeded for the identical sha.

## It was not expiry

That was my first hypothesis and it is wrong, so it is worth stating plainly: `createOrder` defaults `endTime` to `MAX_INT`, so these orders never expire. They had not **started**.

## What actually happens

The simulated chain advances its timestamp **one second per mined block**. Chain time therefore tracks blocks mined, not elapsed real time, and `hre.network.connect()` does not hand each test a fresh clock. Measured directly:

```
genesis:                    chain=1786574848  wall=1786574849  drift=-1
after 5 mines, no delay:    chain=1786574853  wall=1786574849  (+1s per block)
after 4s wall + 1 mine:     chain=1786574857  wall=1786574853
```

Wall clock keeps running whether or not blocks are mined, so a suite that takes longer than the number of blocks it mines leaves chain time behind real time, and it never catches up on its own.

That matters because `createOrder` defaults `startTime` to `Math.floor(Date.now() / 1000)` ([seaport.ts:318](../blob/main/src/seaport.ts#L318)), which is wall clock. Once the drift exceeds the blocks a test mines, every order the test creates has a `startTime` in the chain's future, Seaport skips them all as not yet active, and the multi-order fulfillment reverts with `NoSpecifiedOrdersAvailable()`.

This explains both odd properties of the flake. Coverage-only, because `c8` makes the suite roughly 3x slower in wall clock while mining exactly the same blocks. Intermittent, because it needs total suite wall time to outrun total blocks mined, which depends on runner load.

## The fix

Pull the chain's clock forward to wall clock at the end of the fixture. Forward only: a test that has mined its way ahead of real time is left alone, which is also required because `evm_setNextBlockTimestamp` rejects a timestamp at or behind the current block.

Fixed in the fixture rather than by pinning `startTime` in each test, because it covers every file at once and does not depend on future tests remembering to set it.

## Verification

Reproduced with a temporary wall-clock burn inside the fixture, then removed:

| Scenario | Before | After |
|---|---|---|
| `fulfill-orders.spec.ts`, 25s per test | **7 failing** / 7 passing | 14 passing |
| `ascending-descending-amounts.spec.ts`, 12s per test | 8 passing | 8 passing |
| full suite, normal speed | 160 passing | 164 passing |
| `npm run coverage`, repeated | flaky | 164 passing, stable over 3 runs |

All seven induced failures were `NoSpecifiedOrdersAvailable()`, confirming the mechanism. Worth noting it is **the whole file's multi-order tests**, not only "3 ERC1155 <=> ETH" — the list included `3 ERC721 <=> ERC20`, `ERC20 <=> ERC721`, `3 ERC1155 <=> ERC20`, `ERC20 <=> ERC1155`, and the exactApproval test from #935.

I specifically checked `ascending-descending-amounts.spec.ts`, the file most likely to interact since it drives `evm_setNextBlockTimestamp` itself. It passes with and without this change, because it pins explicit start and end times and is therefore immune to the drift.

## Why there is also a unit test

The drift is invisible in a fast run, so a normal test cannot demonstrate the sync is working. I made the helper injectable (it takes the current time and a minimal provider shape) and tested the four branches directly: advances when behind, no-op when ahead, no-op when exactly equal, no-op when there is no block. That keeps the logic honest without requiring a slow suite.

Test-infrastructure only. No change to shipped code, so no version bump.