### PR TITLE
fix: handle empty domain registry in getDomain

### DIFF
--- a/src/contracts/DomainRegistry.sol
+++ b/src/contracts/DomainRegistry.sol
@@ -121,13 +121,16 @@ contract DomainRegistry is DomainRegistryInterface {
         view
         returns (string memory domain)
     {
-        // Get the maximum possible index of the array of registered domains for the input tag.
-        uint256 maxIndex = _registry[tag].length - 1;
+        // Get the length of the array of registered domains for the input tag.
+        uint256 length = _registry[tag].length;
 
-        // Revert if the index parameter is out of range for the array of domains
-        // corresponding to the tag.
-        if (index > maxIndex) {
-            revert DomainIndexOutOfRange(tag, maxIndex, index);
+        // Avoid underflow when the tag has no registered domains.
+        if (index >= length) {
+            revert DomainIndexOutOfRange(
+                tag,
+                length == 0 ? 0 : length - 1,
+                index
+            );
         }
 
         // Return the domain for the given tag at the given index.

--- a/test/domain-registry.spec.ts
+++ b/test/domain-registry.spec.ts
@@ -104,5 +104,29 @@ describeWithFixture(
         expectedExampleDomainArray,
       )
     })
+
+    it("Should revert with DomainIndexOutOfRange for an unregistered tag", async () => {
+      const { seaport } = fixture
+
+      const unknownTag = "0x12345678"
+
+      await expect(
+        seaport.getDomain(unknownTag, 0),
+      ).to.be.revertedWithCustomError(
+        seaport.domainRegistry,
+        "DomainIndexOutOfRange",
+      )
+    })
+
+    it("Should revert with DomainIndexOutOfRange for an out-of-range index", async () => {
+      const { seaport } = fixture
+
+      await expect(
+        seaport.getDomain(exampleTag, 4),
+      ).to.be.revertedWithCustomError(
+        seaport.domainRegistry,
+        "DomainIndexOutOfRange",
+      )
+    })
   },
 )


### PR DESCRIPTION
Fixed a bug in DomainRegistry.getDomain where querying an unregistered tag caused a Solidity Panic(0x11) due to an array length underflow instead of returning the documented DomainIndexOutOfRange error. The fix performs a safe bounds check without changing the error ABI and adds regression tests for unknown tags and out-of-range indices. All 166 tests pass and the fix was committed and pushed in d7fdcb4