### PR TITLE
fix: explain the out-of-range index when a domain tag has no domains

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -1231,8 +1231,28 @@ export class Seaport {
    * @param index The index.
    * @returns The domain at the index for the given tag.
    */
-  public getDomain(tag: string, index: number): Promise<string> {
-    return this.domainRegistry.getDomain(tag, index)
+  public async getDomain(tag: string, index: number): Promise<string> {
+    try {
+      return await this.domainRegistry.getDomain(tag, index)
+    } catch (error) {
+      // The registry reads `_registry[tag].length - 1` before bounds-checking
+      // the index, so a tag with no registered domains underflows and reverts
+      // with Panic(0x11) instead of DomainIndexOutOfRange. The registry is
+      // deployed and immutable, so the empty case is translated here. A tag
+      // that does have domains already reverts with DomainIndexOutOfRange and
+      // is left to propagate untouched.
+      const totalDomains = await this.domainRegistry
+        .getNumberOfDomains(tag)
+        .catch(() => undefined)
+
+      if (totalDomains === 0n) {
+        throw new Error(
+          `No domains are registered under tag ${tag}, so index ${index} is out of range.`,
+        )
+      }
+
+      throw error
+    }
   }
 
   /**

--- a/test/domain-registry.spec.ts
+++ b/test/domain-registry.spec.ts
@@ -104,5 +104,36 @@ describeWithFixture(
         expectedExampleDomainArray,
       )
     })
+
+    it("Should explain the out-of-range index when the tag has no domains", async () => {
+      const { seaport } = fixture
+
+      const unregisteredTag = "0xdeadbeef"
+
+      expect(await seaport.getNumberOfDomains(unregisteredTag)).to.eq(0)
+
+      // The registry underflows on `length - 1` before it bounds-checks, so
+      // without translation this surfaces as Panic(0x11).
+      await expect(seaport.getDomain(unregisteredTag, 0)).to.be.rejectedWith(
+        `No domains are registered under tag ${unregisteredTag}, so index 0 is out of range.`,
+      )
+    })
+
+    it("Should leave DomainIndexOutOfRange intact when the tag has domains", async () => {
+      const { seaport } = fixture
+
+      await expect(
+        seaport.getDomain(exampleTag, 4),
+      ).to.be.revertedWithCustomError(
+        seaport.domainRegistry,
+        "DomainIndexOutOfRange",
+      )
+    })
+
+    it("Should still return an empty array of domains for an unregistered tag", async () => {
+      const { seaport } = fixture
+
+      expect(await seaport.getDomains("0xdeadbeef")).to.deep.eq([])
+    })
   },
 )


### PR DESCRIPTION
Supersedes #958, which diagnosed this bug correctly but fixed it in a place that cannot reach users. Credit to @Radovenchyk for finding it.

## The bug

`DomainRegistry.getDomain` computes `_registry[tag].length - 1` before it bounds-checks the index. For a tag with no registered domains that underflows, so the call reverts with `Panic(0x11)` instead of the `DomainIndexOutOfRange` the natspec documents.

Confirmed against the deployed registry at `0x000000000DaD0DE04D2B2D4a5A74581EBA94124A` on mainnet:

| Call | Result |
|---|---|
| `getDomain(0xdeadbeef, 0)` | reverts `0x4e487b71...0011` (Panic 0x11) |
| `getNumberOfDomains(0xdeadbeef)` | `0` |
| `getDomains(0xdeadbeef)` | `[]` |
| `getDomain(0x360c6ebe, 99)` on a tag with 1 domain | reverts `0x5370ed68...` (`DomainIndexOutOfRange`) |

So only the empty-tag path is broken. A tag that has domains already reverts with the documented custom error.

## Why not fix the contract

The registry is deployed and immutable, and it is not being redeployed. `src/contracts/DomainRegistry.sol` is compiled and deployed only by the test fixture (`test/utils/setup.ts:102`); in production `Seaport` connects to the fixed `DOMAIN_REGISTRY_ADDRESS` (`src/constants.ts:129`). Editing the Solidity would change the copy the tests deploy, make the repo diverge from deployed bytecode, and leave every real caller hitting the same panic behind a test suite that says otherwise.

## The fix

`getDomain` catches the revert and, only when `getNumberOfDomains(tag)` is `0`, throws an error saying no domains are registered under the tag. Anything else propagates unchanged, so `DomainIndexOutOfRange` still reaches callers who match on it, and an RPC failure still surfaces as an RPC failure rather than being relabeled. The extra `getNumberOfDomains` call is on the failure path only, so a successful lookup still costs one call.

## Testing

172 tests pass, `check-types` clean, Biome clean.

Three tests added to `test/domain-registry.spec.ts`. The fixture deploys the unmodified contract, so they run against the real behavior.

Reverting only `src/seaport.ts` fails exactly the first one, on `panic code 0x11`:

| Test | With fix reverted |
|---|---|
| explains the out-of-range index when the tag has no domains | fails: `reverted with panic code 0x11` instead of the message |
| leaves `DomainIndexOutOfRange` intact when the tag has domains | passes by design, guards against over-translating |
| still returns an empty array of domains for an unregistered tag | passes by design, guards `getDomains` against regressing |

No version bump here, leaving the release to a separate PR as with #953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
