### PR TITLE
fix: validate individual fee basis points

### DIFF
--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -85,6 +85,18 @@ export const deductFees = <T extends Item>(
     return items
   }
 
+  for (const { basisPoints } of fees) {
+    if (
+      !Number.isSafeInteger(basisPoints) ||
+      basisPoints < 0 ||
+      basisPoints > Number(ONE_HUNDRED_PERCENT_BP)
+    ) {
+      throw new Error(
+        `Fee basisPoints (${basisPoints}) must be a safe integer between 0 and ${ONE_HUNDRED_PERCENT_BP} (100%).`,
+      )
+    }
+  }
+
   const totalBasisPoints = fees.reduce(
     (accBasisPoints, fee) => accBasisPoints + fee.basisPoints,
     0,

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -74,7 +74,41 @@ describe("deductFees fee-basisPoints bound", () => {
           },
         ],
       ),
-    ).to.throw("Total fee basisPoints (10001) cannot exceed 10000 (100%)")
+    ).to.throw(
+      "Fee basisPoints (10001) must be a safe integer between 0 and 10000 (100%).",
+    )
+  })
+
+  it("rejects negative fee basisPoints", () => {
+    expect(() =>
+      deductFees(
+        [currencyItem("100")],
+        [
+          {
+            recipient: "0x0000000000000000000000000000000000000001",
+            basisPoints: -1,
+          },
+        ],
+      ),
+    ).to.throw(
+      "Fee basisPoints (-1) must be a safe integer between 0 and 10000 (100%).",
+    )
+  })
+
+  it("rejects fractional fee basisPoints", () => {
+    expect(() =>
+      deductFees(
+        [currencyItem("100")],
+        [
+          {
+            recipient: "0x0000000000000000000000000000000000000001",
+            basisPoints: 0.5,
+          },
+        ],
+      ),
+    ).to.throw(
+      "Fee basisPoints (0.5) must be a safe integer between 0 and 10000 (100%).",
+    )
   })
 })
 


### PR DESCRIPTION
## Summary
- reject every fee `basisPoints` value that is negative, fractional, unsafe, or above 10,000
- keep the existing aggregate 100% cap for otherwise valid fee arrays
- add regression coverage for negative and fractional inputs

## Problem
`deductFees` previously only checked the sum of `basisPoints`. A negative fee could offset an oversized fee, allowing invalid fee values through order construction. Fractional values were also accepted even though Seaport expects integer basis points. Both paths can produce malformed consideration amounts and defer failure to ABI encoding or contract execution.

## Test plan
- `npm test` (174 passing)
- `npm run check-types`
- `npm run build`
- `npx biome check src/utils/order.ts test/utils/order.spec.ts`

## Note
`npm run lint` reaches the same TypeScript check successfully, but the repository-wide Biome phase reports pre-existing CRLF formatting diagnostics across unmodified files in this Windows checkout.
