### PR TITLE
fix: include tips in the fulfiller's balance and approval checks

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -839,6 +839,11 @@ export class Seaport {
 
     const fulfillerOperator = this.config.conduitKeyToConduit[conduitKey]
 
+    const tipConsiderationItems = tips.map(tip => ({
+      ...mapInputItemToOfferItem(tip),
+      recipient: tip.recipient,
+    }))
+
     const [
       offererBalancesAndApprovals,
       fulfillerBalancesAndApprovals,
@@ -853,10 +858,14 @@ export class Seaport {
         operator: offererOperator,
       }),
       // Get fulfiller balances and approvals of all items in the set, as offer items
-      // may be received by the fulfiller for standard fulfills
+      // may be received by the fulfiller for standard fulfills.
+      // Tips are paid by the fulfiller too, and the balance and approval checks
+      // sum them in alongside the order's consideration, so they have to be
+      // covered here as well. A tip in a token the order does not already carry
+      // would otherwise have no entry to look up.
       getBalancesAndApprovals({
         owner: fulfillerAddress,
-        items: [...offer, ...consideration],
+        items: [...offer, ...consideration, ...tipConsiderationItems],
         criterias: [...offerCriteria, ...considerationCriteria],
         provider: this.provider,
         operator: fulfillerOperator,
@@ -883,11 +892,6 @@ export class Seaport {
       ascendingAmountTimestampBuffer:
         this.config.ascendingAmountFulfillmentBuffer,
     }
-
-    const tipConsiderationItems = tips.map(tip => ({
-      ...mapInputItemToOfferItem(tip),
-      recipient: tip.recipient,
-    }))
 
     const isRecipientSelf = recipientAddress === ethers.ZeroAddress
 
@@ -1011,6 +1015,12 @@ export class Seaport {
     const allConsiderationItems = fulfillOrderDetails.flatMap(
       ({ order }) => order.parameters.consideration,
     )
+    const allTipItems = fulfillOrderDetails.map(({ tips = [] }) =>
+      tips.map(tip => ({
+        ...mapInputItemToOfferItem(tip),
+        recipient: tip.recipient,
+      })),
+    )
     const allOfferCriteria = fulfillOrderDetails.flatMap(
       ({ offerCriteria = [] }) => offerCriteria,
     )
@@ -1036,10 +1046,18 @@ export class Seaport {
         ),
       ),
       // Get fulfiller balances and approvals of all items in the set, as offer items
-      // may be received by the fulfiller for standard fulfills
+      // may be received by the fulfiller for standard fulfills.
+      // Tips are paid by the fulfiller too, and the balance and approval checks
+      // sum them in alongside each order's consideration, so they have to be
+      // covered here as well. A tip in a token the orders do not already carry
+      // would otherwise have no entry to look up.
       getBalancesAndApprovals({
         owner: fulfillerAddress,
-        items: [...allOfferItems, ...allConsiderationItems],
+        items: [
+          ...allOfferItems,
+          ...allConsiderationItems,
+          ...allTipItems.flat(),
+        ],
         criterias: [...allOfferCriteria, ...allConsiderationCriteria],
         operator: fulfillerOperator,
         provider: this.provider,
@@ -1063,11 +1081,7 @@ export class Seaport {
           ),
           offerCriteria: orderDetails.offerCriteria ?? [],
           considerationCriteria: orderDetails.considerationCriteria ?? [],
-          tips:
-            orderDetails.tips?.map(tip => ({
-              ...mapInputItemToOfferItem(tip),
-              recipient: tip.recipient,
-            })) ?? [],
+          tips: allTipItems[index],
           extraData: orderDetails.extraData ?? "0x",
           offererBalancesAndApprovals: offerersBalancesAndApprovals[index],
           offererOperator: allOffererOperators[index],

--- a/test/tips.spec.ts
+++ b/test/tips.spec.ts
@@ -1,0 +1,147 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { CreateOrderInput } from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a fulfiller I want to tip in a token the order does not carry",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let fulfiller: HardhatEthersSigner
+    let tipRecipient: HardhatEthersSigner
+    let erc20Listing: CreateOrderInput
+    const nftId = "1"
+    const listingPrice = parseEther("10")
+    const tipAmount = parseEther("1")
+
+    beforeEach(async () => {
+      const { ethers, testErc20, testErc721 } = fixture
+      ;[offerer, , fulfiller, tipRecipient] = await ethers.getSigners()
+
+      await testErc721.mint(await offerer.getAddress(), nftId)
+      await testErc20.mint(await fulfiller.getAddress(), listingPrice)
+
+      erc20Listing = {
+        startTime: "0",
+        offer: [
+          {
+            itemType: ItemType.ERC721,
+            token: await testErc721.getAddress(),
+            identifier: nftId,
+          },
+        ],
+        consideration: [
+          {
+            amount: listingPrice.toString(),
+            token: await testErc20.getAddress(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+      }
+    })
+
+    it("surfaces the approval a second ERC20 tip needs", async () => {
+      const { seaport, testErc20, testErc20USDC, testErc721 } = fixture
+
+      await testErc20USDC.mint(await fulfiller.getAddress(), tipAmount)
+
+      const { executeAllActions } = await seaport.createOrder(
+        erc20Listing,
+        await offerer.getAddress(),
+      )
+      const order = await executeAllActions()
+
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        accountAddress: await fulfiller.getAddress(),
+        tips: [
+          {
+            amount: tipAmount.toString(),
+            token: await testErc20USDC.getAddress(),
+            recipient: await tipRecipient.getAddress(),
+          },
+        ],
+      })
+
+      // The tip is paid by the fulfiller in a token the order never mentions,
+      // so it needs an approval of its own next to the listing currency's.
+      // Without it the fulfillment would revert on the tip transfer.
+      const approvalActions = actions.filter(
+        action => action.type === "approval",
+      )
+
+      expect(approvalActions.map(action => action.token)).to.have.members([
+        await testErc20.getAddress(),
+        await testErc20USDC.getAddress(),
+      ])
+
+      for (const approvalAction of approvalActions) {
+        await approvalAction.transactionMethods.transact()
+      }
+
+      const fulfillAction = actions[actions.length - 1]
+      const transaction = await fulfillAction.transactionMethods.transact()
+      await transaction.wait()
+
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+      expect(
+        await testErc20USDC.balanceOf(await tipRecipient.getAddress()),
+      ).to.eq(tipAmount)
+    })
+
+    it("carries a native tip as msg.value through fulfillOrders", async () => {
+      const { ethers, seaport, testErc721 } = fixture
+
+      const { executeAllActions } = await seaport.createOrder(
+        erc20Listing,
+        await offerer.getAddress(),
+      )
+      const order = await executeAllActions()
+
+      const { actions } = await seaport.fulfillOrders({
+        fulfillOrderDetails: [
+          {
+            order,
+            tips: [
+              {
+                amount: tipAmount.toString(),
+                recipient: await tipRecipient.getAddress(),
+              },
+            ],
+          },
+        ],
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const approvalAction = actions[0]
+      expect(approvalAction.type).to.eq("approval")
+      await approvalAction.transactionMethods.transact()
+
+      // The listing is priced in ERC20, so the tip is the order's only native
+      // item and has to be carried as msg.value.
+      const fulfillAction = actions[actions.length - 1]
+      const transactionRequest =
+        await fulfillAction.transactionMethods.buildTransaction()
+      expect(transactionRequest.value).to.eq(tipAmount)
+
+      const balanceBefore = await ethers.provider.getBalance(
+        await tipRecipient.getAddress(),
+      )
+
+      const transaction = await fulfillAction.transactionMethods.transact()
+      await transaction.wait()
+
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+      expect(
+        (await ethers.provider.getBalance(await tipRecipient.getAddress())) -
+          balanceBefore,
+      ).to.eq(tipAmount)
+    })
+  },
+)


### PR DESCRIPTION
## Problem

`fulfillOrder` and `fulfillOrders` build the fulfiller's balance and approval set from the order's own items only:

```ts
items: [...offer, ...consideration]
```

The checks that read that set sum tips in alongside the consideration. So a tip in a token the order does not already carry has no entry to look up, and `findBalanceAndApproval` throws before any transaction is built:

```
Checking for balance and approvals for token 0x0000000000000000000000000000000000000000 id 0 failed
```

That rules out a native tip on an ERC20 listing, a tip in a second ERC20, and NFT tips, all of which Seaport itself accepts. Tipping in the same token as the order works fine, which is why the existing tip coverage in `partial-fulfill.spec.ts` never hit this.

## Fix

Include the mapped tip items in the fulfiller's lookup set in both entry points. They go on the end, after the order's items, so the offer and consideration criteria mapping in `getItemToCriteriaMap` is untouched.

It also makes the check do its job rather than just stop crashing: a tip in a token the fulfiller has not approved now produces its own approval action, which the fulfillment would revert without.

In `fulfillOrders` the per-order tip mapping is hoisted so it is built once and reused for both the lookup set and `ordersMetadata`, instead of mapped twice.

## Test

`test/tips.spec.ts` covers both entry points. Both fail on `main` with the error above.

- `fulfillOrder` with a second-ERC20 tip: asserts both approval actions appear, then fulfills and checks the NFT and the tip both land.
- `fulfillOrders` with a native tip on an ERC20 listing: asserts the tip rides as `msg.value`, then fulfills and checks the recipient's balance moved.

Suite green at 174.
