### PR TITLE
fix: keep domain-tagged salts a full 32 bytes wide

### DIFF
--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -360,12 +360,18 @@ export function mapTipAmountsFromFilledStatus(
 
 export const generateRandomSalt = (domain?: string) => {
   if (domain) {
+    // Width the hex to a full 32 bytes. `concat` already produces 32 bytes, but
+    // an unwidthed `toBeHex` re-encodes the value as a number and drops leading
+    // zero bytes, so a domain whose hash starts with 0x00 -- roughly one in 256
+    // -- would yield a 31-byte salt whose first four bytes read as the tag
+    // shifted a byte left, leaving the domain unrecoverable from the salt.
     return toBeHex(
       concat([
         keccak256(toUtf8Bytes(domain)).slice(0, 10),
         Uint8Array.from(Array(20).fill(0)),
         randomBytes(8),
       ]),
+      32,
     )
   }
   return `0x${Buffer.from(randomBytes(8)).toString("hex").padStart(64, "0")}`

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -1,7 +1,12 @@
 import { expect } from "chai"
 import { ItemType, OrderType } from "../../src/constants"
 import type { ConsiderationItem, OrderComponents } from "../../src/types"
-import { deductFees, freezeOrderComponents } from "../../src/utils/order"
+import {
+  deductFees,
+  freezeOrderComponents,
+  generateRandomSalt,
+} from "../../src/utils/order"
+import { getTagFromDomain } from "../../src/utils/usecase"
 
 // deductFees subtracts the summed fee basisPoints from every currency item and
 // is the point where an out-of-range fee first turns an order malformed: a total
@@ -157,5 +162,41 @@ describe("freezeOrderComponents", () => {
     Object.freeze(input.offer[0])
     expect(() => freezeOrderComponents(input)).to.not.throw()
     expect(Object.isFrozen(input)).to.be.true
+  })
+})
+
+// A domain-tagged salt carries the first four bytes of keccak256(domain) so the
+// order can be attributed back to the domain it came from. That only works if
+// the salt keeps its full 32-byte width: dropping a leading zero byte shifts
+// every following byte left, and the tag can no longer be read off the salt.
+describe("generateRandomSalt domain tag", () => {
+  const tagOf = (domain: string) => getTagFromDomain(domain)
+
+  // keccak256 of each of these starts with a 0x00 byte
+  const zeroLeadingDomains = ["d362", "d562", "d935"]
+
+  it("keeps the tag readable for a domain hashing to a leading zero byte", () => {
+    for (const domain of zeroLeadingDomains) {
+      const tag = tagOf(domain)
+      expect(tag.slice(0, 2), `${domain} should lead with a zero byte`).to.eq(
+        "00",
+      )
+
+      const salt = generateRandomSalt(domain)
+      expect(salt.slice(2, 10), `tag for ${domain}`).to.eq(tag)
+    }
+  })
+
+  it("emits a full 32-byte salt regardless of the domain", () => {
+    for (const domain of [...zeroLeadingDomains, "opensea.io", "gem.xyz"]) {
+      expect(generateRandomSalt(domain)).to.match(/^0x[0-9a-f]{64}$/)
+    }
+  })
+
+  it("still tags an ordinary domain and pads when no domain is given", () => {
+    expect(generateRandomSalt("opensea.io").slice(2, 10)).to.eq(
+      tagOf("opensea.io"),
+    )
+    expect(generateRandomSalt()).to.match(/^0x0{48}[0-9a-f]{16}$/)
   })
 })


### PR DESCRIPTION
## Summary

Roughly one domain in 256 ends up with a salt that is a byte short, and the domain tag can no longer be read back off it.

## Problem

A domain-tagged salt is four bytes of `keccak256(domain)`, twenty zero bytes, then eight random ones. `concat` assembles exactly 32 bytes. The `toBeHex` wrapped around it has no width argument, so it re-encodes that as a number, and numbers do not keep leading zeros.

Domain `d362` has the tag `00b508f2`. What comes out today:

```
0xb508f2000000000000000000000000000000000000000051be822dec93b6f2   (31 bytes)
```

The first four bytes now read `b508f200`. The tag is still in there, just shifted a place left, so nothing downstream can tell which domain produced the order, which is the only reason to tag the salt.

`test/create-order.spec.ts` already pins the invariant with `expect(order.parameters.salt.slice(0, 10)).eq(openseaMagicValue)`. It is green purely because `keccak256("opensea.io")` happens to start with `0x36`.

Worth being clear on scope: the order itself is fine. `salt` is a `uint256` and both forms carry the same value. I checked against a local chain that `getOrderHash` still agrees with the contract and `validate()` returns true. What breaks is the serialized salt, which is not a well formed `bytes32` and no longer yields the tag.

## Fix

Pass the width: `toBeHex(concat([...]), 32)`. That also makes the size explicit, so ethers raises instead of quietly shortening if the input ever grows past 32 bytes.

It lines the two salt paths up too. A caller supplied salt is already widened to 32 bytes in `_formatOrder`, and `getOrderHash` pads as well, both from #250. The generated branch was the one that never got the same treatment. The no-domain branch needs nothing, it already pads to 64 characters.

## Test plan

`test/utils/order.spec.ts`, no fixture required:

- three domains hashing to a leading zero byte keep their tag readable off the salt
- salts match `/^0x[0-9a-f]{64}$/` for those and for ordinary domains
- control: `opensea.io` still tags correctly and the no-domain path still pads

The first two fail on `main`. Suite green at 175.
