### PR TITLE
fix: account for the domain tag when estimating gas

### DIFF
--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -162,6 +162,19 @@ export const getTransactionMethods = <
     },
     estimateGas: async (overrides?: Overrides) => {
       const mergedOverrides = { ...initialOverrides, ...overrides }
+
+      // With a domain, `transact` sends the calldata that `buildTransaction`
+      // produces, which carries a four byte tag the encoded arguments do not.
+      // Estimating off the arguments alone leaves out the calldata cost of
+      // that tag, so the estimate lands below what the transaction actually
+      // needs and is unusable as a gas limit. Estimate the transaction that
+      // will really be sent instead.
+      if (domain) {
+        return (await signer).estimateGas(
+          await buildTransaction(mergedOverrides),
+        )
+      }
+
       const mergedArgs = [...args, mergedOverrides]
       const method = await contractMethod(signer)
       return method.estimateGas(...mergedArgs)

--- a/test/estimate-gas.spec.ts
+++ b/test/estimate-gas.spec.ts
@@ -1,0 +1,72 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { OrderWithCounter } from "../src/types"
+import { getTagFromDomain } from "../src/utils/usecase"
+import { OPENSEA_DOMAIN } from "./utils/constants"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture("estimateGas on a domain tagged call", fixture => {
+  let offerer: HardhatEthersSigner
+  let order: OrderWithCounter
+
+  beforeEach(async () => {
+    const { ethers, seaport, testErc721 } = fixture
+    ;[offerer] = await ethers.getSigners()
+
+    await testErc721.mint(await offerer.getAddress(), "1")
+
+    const { executeAllActions } = await seaport.createOrder({
+      startTime: "0",
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: await testErc721.getAddress(),
+          identifier: "1",
+        },
+      ],
+      consideration: [
+        {
+          amount: parseEther("1").toString(),
+          recipient: await offerer.getAddress(),
+        },
+      ],
+    })
+
+    order = await executeAllActions()
+  })
+
+  it("covers the gas the appended domain tag costs", async () => {
+    const { seaport } = fixture
+
+    const methods = seaport.validate(
+      [order],
+      await offerer.getAddress(),
+      OPENSEA_DOMAIN,
+    )
+
+    // The tag rides along on the calldata transact sends, so the estimate has
+    // to account for it or it cannot be used as a gas limit.
+    const transaction = await methods.buildTransaction()
+    expect(transaction.data).to.match(
+      new RegExp(`${getTagFromDomain(OPENSEA_DOMAIN)}$`),
+    )
+
+    const estimate = await methods.estimateGas()
+    const receipt = await (await methods.transact()).wait()
+
+    expect(estimate).to.be.gte(receipt!.gasUsed)
+  })
+
+  it("leaves an untagged call estimating the same as before", async () => {
+    const { seaport } = fixture
+
+    const methods = seaport.validate([order], await offerer.getAddress())
+
+    const estimate = await methods.estimateGas()
+    const receipt = await (await methods.transact()).wait()
+
+    expect(estimate).to.be.gte(receipt!.gasUsed)
+  })
+})


### PR DESCRIPTION
## What happened

With a `domain` set, `buildTransaction` appends its four byte tag to the calldata, and `transact` sends exactly that. `estimateGas` never goes through it, it calls the contract method with the encoded arguments only, so those four bytes are not part of what gets measured.

Calldata is charged per byte, so the number comes back short. On a `validate()` call:

```
estimateGas()   65562
gasUsed         65626
```

Feed that estimate straight back in as a gas limit, which is the usual reason to ask for one, and the transaction runs out of gas.

## The fix

When a domain is set, estimate the transaction `buildTransaction` produces, so the calldata being measured is the calldata being sent. Without a domain the call goes through the contract method exactly as before.

## Scope

`staticCall` has the same gap, but Seaport ignores the trailing bytes and returns the same result either way, so I left it alone rather than change something with no observable effect.

## Testing

`test/estimate-gas.spec.ts`: one test asserts the estimate covers `gasUsed` on a tagged call, one does the same for an untagged call as a control. The first fails on `main`, the second passes either way. Suite green at 174.
