### PR TITLE
fix(utils): make generateRandomSalt isomorphic and findBalanceAndApproval null-safe

### DIFF
--- a/src/utils/balanceAndApprovalCheck.ts
+++ b/src/utils/balanceAndApprovalCheck.ts
@@ -42,14 +42,16 @@ const findBalanceAndApproval = (
   token: string,
   identifierOrCriteria: string,
 ) => {
+  const targetToken = (token ?? "").toLowerCase()
+  const targetId = (identifierOrCriteria ?? "0").toLowerCase()
+
   const balanceAndApproval = balancesAndApprovals.find(
     ({
       token: checkedToken,
       identifierOrCriteria: checkedIdentifierOrCriteria,
     }) =>
-      token.toLowerCase() === checkedToken.toLowerCase() &&
-      checkedIdentifierOrCriteria.toLowerCase() ===
-        identifierOrCriteria.toLowerCase(),
+      (checkedToken ?? "").toLowerCase() === targetToken &&
+      (checkedIdentifierOrCriteria ?? "0").toLowerCase() === targetId,
   )
 
   if (!balanceAndApproval) {

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -2,6 +2,7 @@ import {
   type BigNumberish,
   concat,
   ethers,
+  hexlify,
   keccak256,
   randomBytes,
   toBeHex,
@@ -363,12 +364,13 @@ export const generateRandomSalt = (domain?: string) => {
     return toBeHex(
       concat([
         keccak256(toUtf8Bytes(domain)).slice(0, 10),
-        Uint8Array.from(Array(20).fill(0)),
+        new Uint8Array(20),
         randomBytes(8),
       ]),
+      32,
     )
   }
-  return `0x${Buffer.from(randomBytes(8)).toString("hex").padStart(64, "0")}`
+  return hexlify(concat([new Uint8Array(24), randomBytes(8)]))
 }
 
 export const shouldUseMatchForFulfill = () => true

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from "chai"
 import { ItemType, OrderType } from "../../src/constants"
 import type { ConsiderationItem, OrderComponents } from "../../src/types"
-import { deductFees, freezeOrderComponents } from "../../src/utils/order"
+import {
+  deductFees,
+  freezeOrderComponents,
+  generateRandomSalt,
+} from "../../src/utils/order"
 
 // deductFees subtracts the summed fee basisPoints from every currency item and
 // is the point where an out-of-range fee first turns an order malformed: a total
@@ -159,3 +163,23 @@ describe("freezeOrderComponents", () => {
     expect(Object.isFrozen(input)).to.be.true
   })
 })
+
+describe("generateRandomSalt", () => {
+  it("generates a 32-byte hex salt without domain", () => {
+    const salt = generateRandomSalt()
+    expect(salt).to.match(/^0x[0-9a-fA-F]{64}$/)
+  })
+
+  it("generates a 32-byte hex salt with domain tag", () => {
+    const salt = generateRandomSalt("opensea.io")
+    expect(salt).to.match(/^0x[0-9a-fA-F]{64}$/)
+    expect(salt.slice(0, 10)).to.equal("0x367f0174")
+  })
+
+  it("generates unique salts across multiple calls", () => {
+    const salt1 = generateRandomSalt()
+    const salt2 = generateRandomSalt()
+    expect(salt1).to.not.equal(salt2)
+  })
+})
+


### PR DESCRIPTION
## Motivation

1. **Browser / Bundler Compatibility for `generateRandomSalt`**:
   - In `src/utils/order.ts`, when generating a random salt without a domain, `generateRandomSalt` previously called `Buffer.from(randomBytes(8)).toString("hex")`.
   - In frontend application bundles (Vite, Webpack 5, Next.js client components, browser-native environments), Node.js `Buffer` is not globally available by default, leading to `ReferenceError: Buffer is not defined` when creating orders client-side.
   - Furthermore, when a domain tag is provided, `toBeHex` was called without an explicit 32-byte width, which can emit a 31-byte hex string if the domain hash begins with `0x00`.

2. **Null-Safe Token & Identifier Lookup in `findBalanceAndApproval`**:
   - In `src/utils/balanceAndApprovalCheck.ts`, `findBalanceAndApproval` executed `.toLowerCase()` directly on `checkedIdentifierOrCriteria` and `identifierOrCriteria`. For fungible / native currency lookups where identifiers may be omitted or undefined, this could trigger an unhandled `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.

## Solution

1. **Isomorphic & Width-Safe Salt Generation (`src/utils/order.ts`)**:
   - Replaced Node's `Buffer` usage with ethers' standard `hexlify(concat([new Uint8Array(24), randomBytes(8)]))` for the domain-free branch, producing the exact 32-byte (64 hex character) padded salt isomorphically across Node.js, browsers, and edge runtimes.
   - Added explicit `32` byte width parameter to `toBeHex(concat([...]), 32)` for domain-tagged salts.
   - Added unit test suite in `test/utils/order.spec.ts` asserting format, length (32 bytes / 64 hex digits), domain tag retention, and randomness.

2. **Defensive Nullish Coalescing in `findBalanceAndApproval` (`src/utils/balanceAndApprovalCheck.ts`)**:
   - Normalized `token` and `identifierOrCriteria` with `(token ?? "").toLowerCase()` and `(identifierOrCriteria ?? "0").toLowerCase()`.
