### PR TITLE
fix: tips in balance checks, salt width, fee bounds, gas estimate (7 community contributions)

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -839,6 +839,11 @@ export class Seaport {
 
     const fulfillerOperator = this.config.conduitKeyToConduit[conduitKey]
 
+    const tipConsiderationItems = tips.map(tip => ({
+      ...mapInputItemToOfferItem(tip),
+      recipient: tip.recipient,
+    }))
+
     const [
       offererBalancesAndApprovals,
       fulfillerBalancesAndApprovals,
@@ -853,10 +858,14 @@ export class Seaport {
         operator: offererOperator,
       }),
       // Get fulfiller balances and approvals of all items in the set, as offer items
-      // may be received by the fulfiller for standard fulfills
+      // may be received by the fulfiller for standard fulfills.
+      // Tips are paid by the fulfiller too, and the balance and approval checks
+      // sum them in alongside the order's consideration, so they have to be
+      // covered here as well. A tip in a token the order does not already carry
+      // would otherwise have no entry to look up.
       getBalancesAndApprovals({
         owner: fulfillerAddress,
-        items: [...offer, ...consideration],
+        items: [...offer, ...consideration, ...tipConsiderationItems],
         criterias: [...offerCriteria, ...considerationCriteria],
         provider: this.provider,
         operator: fulfillerOperator,
@@ -883,11 +892,6 @@ export class Seaport {
       ascendingAmountTimestampBuffer:
         this.config.ascendingAmountFulfillmentBuffer,
     }
-
-    const tipConsiderationItems = tips.map(tip => ({
-      ...mapInputItemToOfferItem(tip),
-      recipient: tip.recipient,
-    }))
 
     const isRecipientSelf = recipientAddress === ethers.ZeroAddress
 
@@ -1011,6 +1015,12 @@ export class Seaport {
     const allConsiderationItems = fulfillOrderDetails.flatMap(
       ({ order }) => order.parameters.consideration,
     )
+    const allTipItems = fulfillOrderDetails.map(({ tips = [] }) =>
+      tips.map(tip => ({
+        ...mapInputItemToOfferItem(tip),
+        recipient: tip.recipient,
+      })),
+    )
     const allOfferCriteria = fulfillOrderDetails.flatMap(
       ({ offerCriteria = [] }) => offerCriteria,
     )
@@ -1036,10 +1046,18 @@ export class Seaport {
         ),
       ),
       // Get fulfiller balances and approvals of all items in the set, as offer items
-      // may be received by the fulfiller for standard fulfills
+      // may be received by the fulfiller for standard fulfills.
+      // Tips are paid by the fulfiller too, and the balance and approval checks
+      // sum them in alongside each order's consideration, so they have to be
+      // covered here as well. A tip in a token the orders do not already carry
+      // would otherwise have no entry to look up.
       getBalancesAndApprovals({
         owner: fulfillerAddress,
-        items: [...allOfferItems, ...allConsiderationItems],
+        items: [
+          ...allOfferItems,
+          ...allConsiderationItems,
+          ...allTipItems.flat(),
+        ],
         criterias: [...allOfferCriteria, ...allConsiderationCriteria],
         operator: fulfillerOperator,
         provider: this.provider,
@@ -1063,11 +1081,7 @@ export class Seaport {
           ),
           offerCriteria: orderDetails.offerCriteria ?? [],
           considerationCriteria: orderDetails.considerationCriteria ?? [],
-          tips:
-            orderDetails.tips?.map(tip => ({
-              ...mapInputItemToOfferItem(tip),
-              recipient: tip.recipient,
-            })) ?? [],
+          tips: allTipItems[index],
           extraData: orderDetails.extraData ?? "0x",
           offererBalancesAndApprovals: offerersBalancesAndApprovals[index],
           offererOperator: allOffererOperators[index],

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -395,9 +395,24 @@ export function fulfillStandardOrder(
   let adjustedTips: ConsiderationItem[] = []
 
   if (tips.length > 0) {
-    adjustedTips = unitsToFill
-      ? mapTipAmountsFromUnitsToFill(tips, unitsToFill, totalSize)
-      : mapTipAmountsFromFilledStatus(tips, totalFilled, totalSize)
+    if (unitsToFill) {
+      // mapOrderAmountsFromUnitsToFill resolves a totalSize of 0 (an order
+      // that hasn't been partially filled yet) to the order's own maximum
+      // size internally; tips must be scaled by that same resolved value,
+      // or a raw totalSize of 0 passed straight through divides by zero.
+      const resolvedTotalSize =
+        totalSize === 0n ? getMaximumSizeForOrder(order) : totalSize
+      adjustedTips = mapTipAmountsFromUnitsToFill(
+        tips,
+        unitsToFill,
+        resolvedTotalSize,
+      )
+    } else {
+      // mapTipAmountsFromFilledStatus already treats totalSize === 0n as
+      // "leave unscaled", matching mapOrderAmountsFromFilledStatus above -
+      // no resolution needed here.
+      adjustedTips = mapTipAmountsFromFilledStatus(tips, totalFilled, totalSize)
+    }
   }
 
   const {
@@ -607,17 +622,29 @@ export function fulfillAvailableOrders({
       return []
     }
 
-    return orderMetadata.unitsToFill
-      ? mapTipAmountsFromUnitsToFill(
-          orderMetadata.tips,
-          orderMetadata.unitsToFill,
-          orderMetadata.orderStatus.totalSize,
-        )
-      : mapTipAmountsFromFilledStatus(
-          orderMetadata.tips,
-          orderMetadata.orderStatus.totalFilled,
-          orderMetadata.orderStatus.totalSize,
-        )
+    if (orderMetadata.unitsToFill) {
+      // mapOrderAmountsFromUnitsToFill (used just below for the order
+      // itself) resolves a totalSize of 0 to the order's own maximum size
+      // internally; tips must be scaled by that same resolved value, or a
+      // raw totalSize of 0 passed straight through divides by zero.
+      const resolvedTotalSize =
+        orderMetadata.orderStatus.totalSize === 0n
+          ? getMaximumSizeForOrder(orderMetadata.order)
+          : orderMetadata.orderStatus.totalSize
+      return mapTipAmountsFromUnitsToFill(
+        orderMetadata.tips,
+        orderMetadata.unitsToFill,
+        resolvedTotalSize,
+      )
+    }
+    // mapTipAmountsFromFilledStatus already treats totalSize === 0n as
+    // "leave unscaled", matching mapOrderAmountsFromFilledStatus below - no
+    // resolution needed here.
+    return mapTipAmountsFromFilledStatus(
+      orderMetadata.tips,
+      orderMetadata.orderStatus.totalFilled,
+      orderMetadata.orderStatus.totalSize,
+    )
   }
 
   const ordersMetadataWithAdjustedFills = sanitizedOrdersMetadata.map(

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -85,6 +85,18 @@ export const deductFees = <T extends Item>(
     return items
   }
 
+  for (const { basisPoints } of fees) {
+    if (
+      !Number.isSafeInteger(basisPoints) ||
+      basisPoints < 0 ||
+      basisPoints > Number(ONE_HUNDRED_PERCENT_BP)
+    ) {
+      throw new Error(
+        `Fee basisPoints (${basisPoints}) must be a safe integer between 0 and ${ONE_HUNDRED_PERCENT_BP} (100%).`,
+      )
+    }
+  }
+
   const totalBasisPoints = fees.reduce(
     (accBasisPoints, fee) => accBasisPoints + fee.basisPoints,
     0,

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -360,12 +360,18 @@ export function mapTipAmountsFromFilledStatus(
 
 export const generateRandomSalt = (domain?: string) => {
   if (domain) {
+    // Width the hex to a full 32 bytes. `concat` already produces 32 bytes, but
+    // an unwidthed `toBeHex` re-encodes the value as a number and drops leading
+    // zero bytes, so a domain whose hash starts with 0x00 -- roughly one in 256
+    // -- would yield a 31-byte salt whose first four bytes read as the tag
+    // shifted a byte left, leaving the domain unrecoverable from the salt.
     return toBeHex(
       concat([
         keccak256(toUtf8Bytes(domain)).slice(0, 10),
         Uint8Array.from(Array(20).fill(0)),
         randomBytes(8),
       ]),
+      32,
     )
   }
   return `0x${Buffer.from(randomBytes(8)).toString("hex").padStart(64, "0")}`

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -2,6 +2,7 @@ import {
   type BigNumberish,
   concat,
   ethers,
+  hexlify,
   keccak256,
   randomBytes,
   toBeHex,
@@ -386,7 +387,11 @@ export const generateRandomSalt = (domain?: string) => {
       32,
     )
   }
-  return `0x${Buffer.from(randomBytes(8)).toString("hex").padStart(64, "0")}`
+  // `Buffer` is a Node global that browser bundlers do not polyfill by default,
+  // and this branch is on the hot path: opensea-sdk calls generateRandomSalt()
+  // with no domain when it builds a private-listing counter order. Build the
+  // same 24 zero bytes plus 8 random bytes out of ethers primitives instead.
+  return hexlify(concat([new Uint8Array(24), randomBytes(8)]))
 }
 
 export const shouldUseMatchForFulfill = () => true

--- a/src/utils/usecase.ts
+++ b/src/utils/usecase.ts
@@ -162,6 +162,19 @@ export const getTransactionMethods = <
     },
     estimateGas: async (overrides?: Overrides) => {
       const mergedOverrides = { ...initialOverrides, ...overrides }
+
+      // With a domain, `transact` sends the calldata that `buildTransaction`
+      // produces, which carries a four byte tag the encoded arguments do not.
+      // Estimating off the arguments alone leaves out the calldata cost of
+      // that tag, so the estimate lands below what the transaction actually
+      // needs and is unusable as a gas limit. Estimate the transaction that
+      // will really be sent instead.
+      if (domain) {
+        return (await signer).estimateGas(
+          await buildTransaction(mergedOverrides),
+        )
+      }
+
       const mergedArgs = [...args, mergedOverrides]
       const method = await contractMethod(signer)
       return method.estimateGas(...mergedArgs)

--- a/test/estimate-gas.spec.ts
+++ b/test/estimate-gas.spec.ts
@@ -1,0 +1,72 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { OrderWithCounter } from "../src/types"
+import { getTagFromDomain } from "../src/utils/usecase"
+import { OPENSEA_DOMAIN } from "./utils/constants"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture("estimateGas on a domain tagged call", fixture => {
+  let offerer: HardhatEthersSigner
+  let order: OrderWithCounter
+
+  beforeEach(async () => {
+    const { ethers, seaport, testErc721 } = fixture
+    ;[offerer] = await ethers.getSigners()
+
+    await testErc721.mint(await offerer.getAddress(), "1")
+
+    const { executeAllActions } = await seaport.createOrder({
+      startTime: "0",
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: await testErc721.getAddress(),
+          identifier: "1",
+        },
+      ],
+      consideration: [
+        {
+          amount: parseEther("1").toString(),
+          recipient: await offerer.getAddress(),
+        },
+      ],
+    })
+
+    order = await executeAllActions()
+  })
+
+  it("covers the gas the appended domain tag costs", async () => {
+    const { seaport } = fixture
+
+    const methods = seaport.validate(
+      [order],
+      await offerer.getAddress(),
+      OPENSEA_DOMAIN,
+    )
+
+    // The tag rides along on the calldata transact sends, so the estimate has
+    // to account for it or it cannot be used as a gas limit.
+    const transaction = await methods.buildTransaction()
+    expect(transaction.data).to.match(
+      new RegExp(`${getTagFromDomain(OPENSEA_DOMAIN)}$`),
+    )
+
+    const estimate = await methods.estimateGas()
+    const receipt = await (await methods.transact()).wait()
+
+    expect(estimate).to.be.gte(receipt!.gasUsed)
+  })
+
+  it("leaves an untagged call estimating the same as before", async () => {
+    const { seaport } = fixture
+
+    const methods = seaport.validate([order], await offerer.getAddress())
+
+    const estimate = await methods.estimateGas()
+    const receipt = await (await methods.transact()).wait()
+
+    expect(estimate).to.be.gte(receipt!.gasUsed)
+  })
+})

--- a/test/tips.spec.ts
+++ b/test/tips.spec.ts
@@ -1,0 +1,147 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { CreateOrderInput } from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a fulfiller I want to tip in a token the order does not carry",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let fulfiller: HardhatEthersSigner
+    let tipRecipient: HardhatEthersSigner
+    let erc20Listing: CreateOrderInput
+    const nftId = "1"
+    const listingPrice = parseEther("10")
+    const tipAmount = parseEther("1")
+
+    beforeEach(async () => {
+      const { ethers, testErc20, testErc721 } = fixture
+      ;[offerer, , fulfiller, tipRecipient] = await ethers.getSigners()
+
+      await testErc721.mint(await offerer.getAddress(), nftId)
+      await testErc20.mint(await fulfiller.getAddress(), listingPrice)
+
+      erc20Listing = {
+        startTime: "0",
+        offer: [
+          {
+            itemType: ItemType.ERC721,
+            token: await testErc721.getAddress(),
+            identifier: nftId,
+          },
+        ],
+        consideration: [
+          {
+            amount: listingPrice.toString(),
+            token: await testErc20.getAddress(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+      }
+    })
+
+    it("surfaces the approval a second ERC20 tip needs", async () => {
+      const { seaport, testErc20, testErc20USDC, testErc721 } = fixture
+
+      await testErc20USDC.mint(await fulfiller.getAddress(), tipAmount)
+
+      const { executeAllActions } = await seaport.createOrder(
+        erc20Listing,
+        await offerer.getAddress(),
+      )
+      const order = await executeAllActions()
+
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        accountAddress: await fulfiller.getAddress(),
+        tips: [
+          {
+            amount: tipAmount.toString(),
+            token: await testErc20USDC.getAddress(),
+            recipient: await tipRecipient.getAddress(),
+          },
+        ],
+      })
+
+      // The tip is paid by the fulfiller in a token the order never mentions,
+      // so it needs an approval of its own next to the listing currency's.
+      // Without it the fulfillment would revert on the tip transfer.
+      const approvalActions = actions.filter(
+        action => action.type === "approval",
+      )
+
+      expect(approvalActions.map(action => action.token)).to.have.members([
+        await testErc20.getAddress(),
+        await testErc20USDC.getAddress(),
+      ])
+
+      for (const approvalAction of approvalActions) {
+        await approvalAction.transactionMethods.transact()
+      }
+
+      const fulfillAction = actions[actions.length - 1]
+      const transaction = await fulfillAction.transactionMethods.transact()
+      await transaction.wait()
+
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+      expect(
+        await testErc20USDC.balanceOf(await tipRecipient.getAddress()),
+      ).to.eq(tipAmount)
+    })
+
+    it("carries a native tip as msg.value through fulfillOrders", async () => {
+      const { ethers, seaport, testErc721 } = fixture
+
+      const { executeAllActions } = await seaport.createOrder(
+        erc20Listing,
+        await offerer.getAddress(),
+      )
+      const order = await executeAllActions()
+
+      const { actions } = await seaport.fulfillOrders({
+        fulfillOrderDetails: [
+          {
+            order,
+            tips: [
+              {
+                amount: tipAmount.toString(),
+                recipient: await tipRecipient.getAddress(),
+              },
+            ],
+          },
+        ],
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const approvalAction = actions[0]
+      expect(approvalAction.type).to.eq("approval")
+      await approvalAction.transactionMethods.transact()
+
+      // The listing is priced in ERC20, so the tip is the order's only native
+      // item and has to be carried as msg.value.
+      const fulfillAction = actions[actions.length - 1]
+      const transactionRequest =
+        await fulfillAction.transactionMethods.buildTransaction()
+      expect(transactionRequest.value).to.eq(tipAmount)
+
+      const balanceBefore = await ethers.provider.getBalance(
+        await tipRecipient.getAddress(),
+      )
+
+      const transaction = await fulfillAction.transactionMethods.transact()
+      await transaction.wait()
+
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+      expect(
+        (await ethers.provider.getBalance(await tipRecipient.getAddress())) -
+          balanceBefore,
+      ).to.eq(tipAmount)
+    })
+  },
+)

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -79,7 +79,41 @@ describe("deductFees fee-basisPoints bound", () => {
           },
         ],
       ),
-    ).to.throw("Total fee basisPoints (10001) cannot exceed 10000 (100%)")
+    ).to.throw(
+      "Fee basisPoints (10001) must be a safe integer between 0 and 10000 (100%).",
+    )
+  })
+
+  it("rejects negative fee basisPoints", () => {
+    expect(() =>
+      deductFees(
+        [currencyItem("100")],
+        [
+          {
+            recipient: "0x0000000000000000000000000000000000000001",
+            basisPoints: -1,
+          },
+        ],
+      ),
+    ).to.throw(
+      "Fee basisPoints (-1) must be a safe integer between 0 and 10000 (100%).",
+    )
+  })
+
+  it("rejects fractional fee basisPoints", () => {
+    expect(() =>
+      deductFees(
+        [currencyItem("100")],
+        [
+          {
+            recipient: "0x0000000000000000000000000000000000000001",
+            basisPoints: 0.5,
+          },
+        ],
+      ),
+    ).to.throw(
+      "Fee basisPoints (0.5) must be a safe integer between 0 and 10000 (100%).",
+    )
   })
 })
 

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -1,10 +1,12 @@
 import { expect } from "chai"
 import { ItemType, OrderType } from "../../src/constants"
 import type { ConsiderationItem, OrderComponents } from "../../src/types"
+import { MerkleTree } from "../../src/utils/merkletree"
 import {
   deductFees,
   freezeOrderComponents,
   generateRandomSalt,
+  mapInputItemToOfferItem,
 } from "../../src/utils/order"
 import { getTagFromDomain } from "../../src/utils/usecase"
 
@@ -232,5 +234,145 @@ describe("generateRandomSalt domain tag", () => {
       tagOf("opensea.io"),
     )
     expect(generateRandomSalt()).to.match(/^0x0{48}[0-9a-f]{16}$/)
+  })
+})
+
+// mapInputItemToOfferItem is the single normalizer every createOrder input item
+// passes through on its way to a Seaport OfferItem: it fans a CreateInputItem
+// (basic ERC721/ERC1155, criteria items, and bare currency items) out into the
+// fully-populated { itemType, token, identifierOrCriteria, startAmount, endAmount }
+// shape the protocol signs over, applying the amount defaults each variant
+// relies on. It is only otherwise exercised indirectly through the
+// hardhat-network-backed create-order specs, so pin its branch-by-branch
+// behavior here as fast, isolated units.
+describe("mapInputItemToOfferItem", () => {
+  const token = "0x0000000000000000000000000000000000000005"
+  const ZERO = "0x0000000000000000000000000000000000000000"
+
+  it("maps a basic ERC721 item, defaulting both amounts to 1", () => {
+    expect(
+      mapInputItemToOfferItem({
+        itemType: ItemType.ERC721,
+        token,
+        identifier: "42",
+      }),
+    ).to.deep.equal({
+      itemType: ItemType.ERC721,
+      token,
+      identifierOrCriteria: "42",
+      startAmount: "1",
+      endAmount: "1",
+    })
+  })
+
+  it("maps a basic ERC1155 item, defaulting endAmount to the start amount", () => {
+    expect(
+      mapInputItemToOfferItem({
+        itemType: ItemType.ERC1155,
+        token,
+        identifier: "7",
+        amount: "5",
+      }),
+    ).to.deep.equal({
+      itemType: ItemType.ERC1155,
+      token,
+      identifierOrCriteria: "7",
+      startAmount: "5",
+      endAmount: "5",
+    })
+  })
+
+  it("preserves distinct start and end amounts for an ascending ERC1155 item", () => {
+    const offerItem = mapInputItemToOfferItem({
+      itemType: ItemType.ERC1155,
+      token,
+      identifier: "7",
+      amount: "5",
+      endAmount: "10",
+    })
+    expect(offerItem.startAmount).to.eq("5")
+    expect(offerItem.endAmount).to.eq("10")
+  })
+
+  it("maps an ERC721 criteria item given an explicit merkle root", () => {
+    expect(
+      mapInputItemToOfferItem({
+        itemType: ItemType.ERC721,
+        token,
+        criteria: "123",
+      }),
+    ).to.deep.equal({
+      itemType: ItemType.ERC721_WITH_CRITERIA,
+      token,
+      identifierOrCriteria: "123",
+      startAmount: "1",
+      endAmount: "1",
+    })
+  })
+
+  it("maps an ERC1155 criteria item, keeping its amount", () => {
+    expect(
+      mapInputItemToOfferItem({
+        itemType: ItemType.ERC1155,
+        token,
+        amount: "2",
+        criteria: "456",
+      }),
+    ).to.deep.equal({
+      itemType: ItemType.ERC1155_WITH_CRITERIA,
+      token,
+      identifierOrCriteria: "456",
+      startAmount: "2",
+      endAmount: "2",
+    })
+  })
+
+  it("derives the merkle root from identifiers for a criteria item", () => {
+    const identifiers = ["1", "2", "3"]
+    const offerItem = mapInputItemToOfferItem({
+      itemType: ItemType.ERC721,
+      token,
+      identifiers,
+    })
+    expect(offerItem.itemType).to.eq(ItemType.ERC721_WITH_CRITERIA)
+    expect(offerItem.identifierOrCriteria).to.eq(
+      new MerkleTree(identifiers).getRoot(),
+    )
+  })
+
+  it("maps a currency item with a token to ERC20", () => {
+    expect(mapInputItemToOfferItem({ token, amount: "1000" })).to.deep.equal({
+      itemType: ItemType.ERC20,
+      token,
+      identifierOrCriteria: "0",
+      startAmount: "1000",
+      endAmount: "1000",
+    })
+  })
+
+  it("maps a currency item without a token to native", () => {
+    expect(mapInputItemToOfferItem({ amount: "1000" })).to.deep.equal({
+      itemType: ItemType.NATIVE,
+      token: ZERO,
+      identifierOrCriteria: "0",
+      startAmount: "1000",
+      endAmount: "1000",
+    })
+  })
+
+  it("treats the zero-address token as native, not ERC20", () => {
+    expect(
+      mapInputItemToOfferItem({ token: ZERO, amount: "1000" }).itemType,
+    ).to.eq(ItemType.NATIVE)
+  })
+
+  it("preserves a descending currency end amount", () => {
+    const offerItem = mapInputItemToOfferItem({
+      token,
+      amount: "1000",
+      endAmount: "900",
+    })
+    expect(offerItem.startAmount).to.eq("1000")
+    expect(offerItem.endAmount).to.eq("900")
   })
 })

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -237,6 +237,25 @@ describe("generateRandomSalt domain tag", () => {
   })
 })
 
+// seaport-js is consumed from browsers as well as Node, and bundlers do not
+// polyfill the `Buffer` global by default. `generateRandomSalt` is on the hot
+// path -- opensea-sdk calls the no-domain branch when it builds a private
+// listing counter order -- so pin that neither branch reaches for a Node global.
+// Nothing else in the suite can catch this, because Node always defines Buffer.
+describe("generateRandomSalt without Node globals", () => {
+  it("builds a salt in an environment with no Buffer", () => {
+    const originalBuffer = globalThis.Buffer
+    // @ts-expect-error deleting a Node global to stand in for a browser bundle
+    delete globalThis.Buffer
+    try {
+      expect(generateRandomSalt()).to.match(/^0x0{48}[0-9a-f]{16}$/)
+      expect(generateRandomSalt("opensea.io")).to.match(/^0x[0-9a-f]{64}$/)
+    } finally {
+      globalThis.Buffer = originalBuffer
+    }
+  })
+})
+
 // mapInputItemToOfferItem is the single normalizer every createOrder input item
 // passes through on its way to a Seaport OfferItem: it fans a CreateInputItem
 // (basic ERC721/ERC1155, criteria items, and bare currency items) out into the

--- a/test/utils/order.spec.ts
+++ b/test/utils/order.spec.ts
@@ -1,7 +1,12 @@
 import { expect } from "chai"
 import { ItemType, OrderType } from "../../src/constants"
 import type { ConsiderationItem, OrderComponents } from "../../src/types"
-import { deductFees, freezeOrderComponents } from "../../src/utils/order"
+import {
+  deductFees,
+  freezeOrderComponents,
+  generateRandomSalt,
+} from "../../src/utils/order"
+import { getTagFromDomain } from "../../src/utils/usecase"
 
 // deductFees subtracts the summed fee basisPoints from every currency item and
 // is the point where an out-of-range fee first turns an order malformed: a total
@@ -157,5 +162,41 @@ describe("freezeOrderComponents", () => {
     Object.freeze(input.offer[0])
     expect(() => freezeOrderComponents(input)).to.not.throw()
     expect(Object.isFrozen(input)).to.be.true
+  })
+})
+
+// A domain-tagged salt carries the first four bytes of keccak256(domain) so the
+// order can be attributed back to the domain it came from. That only works if
+// the salt keeps its full 32-byte width: dropping a leading zero byte shifts
+// every following byte left, and the tag can no longer be read off the salt.
+describe("generateRandomSalt domain tag", () => {
+  const tagOf = (domain: string) => getTagFromDomain(domain)
+
+  // keccak256 of each of these starts with a 0x00 byte
+  const zeroLeadingDomains = ["d362", "d562", "d935"]
+
+  it("keeps the tag readable for a domain hashing to a leading zero byte", () => {
+    for (const domain of zeroLeadingDomains) {
+      const tag = tagOf(domain)
+      expect(tag.slice(0, 2), `${domain} should lead with a zero byte`).to.eq(
+        "00",
+      )
+
+      const salt = generateRandomSalt(domain)
+      expect(salt.slice(2, 10), `tag for ${domain}`).to.eq(tag)
+    }
+  })
+
+  it("emits a full 32-byte salt regardless of the domain", () => {
+    for (const domain of [...zeroLeadingDomains, "opensea.io", "gem.xyz"]) {
+      expect(generateRandomSalt(domain)).to.match(/^0x[0-9a-f]{64}$/)
+    }
+  })
+
+  it("still tags an ordinary domain and pads when no domain is given", () => {
+    expect(generateRandomSalt("opensea.io").slice(2, 10)).to.eq(
+      tagOf("opensea.io"),
+    )
+    expect(generateRandomSalt()).to.match(/^0x0{48}[0-9a-f]{16}$/)
   })
 })


### PR DESCRIPTION
Stacks seven open community contributions onto one branch. Each contributor's commit is preserved with their authorship. The individual PRs are superseded and closed pointing here.

Four of them collided in `src/utils/order.ts` and `test/utils/order.spec.ts`, so reviewing and merging them as one series is cheaper than seven rebases.

| Source | Author | What it does |
|---|---|---|
| #962 | @Dusk1e | Include tips in the fulfiller's balance and approval set. Tipping in a token the order does not carry throws today. |
| #964 | @Ruzzgar | `estimateGas` was estimating untagged arguments while `transact` sends tagged calldata. |
| #971 | @chalomdev | Resolve a zero `totalSize` before scaling tips. Hardening, not a live fix, see below. |
| #963 | @Xowiek | Keep domain-tagged salts a full 32 bytes. An unwidthed `toBeHex` drops a leading zero byte. |
| #961 | @wodesiku | Bound individual fee `basisPoints`, not just the total. |
| #970 | @devorun | Unit coverage for `mapInputItemToOfferItem`. |
| #969 | @vhtgzzl | Buffer half only. The salt half duplicated #963, and its test asserted a wrong tag value. |

## Verification

Every source fix was checked by reverting only its source hunk and confirming its test fails on the assertion it is named for:

- #962: both tests fail with `Checking for balance and approvals for token ... failed`
- #963: two tests fail, output shows the 31-byte salt `0xb508f200...`
- #961: three tests fail, including the pre-existing case whose message changes
- #964: `expected 65574 to be at least 65638`, so the real shortfall is 64 gas
- #969 Buffer half: had no coverage at all, so this branch adds a test that deletes the global and fails with `ReferenceError: Buffer is not defined` without the fix
- #971: reverting it leaves all 191 tests passing, which is why it is labeled hardening

## On #971

`scaleOrderStatusToMaxUnits` already rewrites a zero `totalSize` at both call sites (`src/seaport.ts:870` and `:1060`) before `totalSize` reaches `fulfillStandardOrder` or `fulfillAvailableOrders`, so the divide-by-zero is not reachable through the public API. Taken because the invariant is currently protected only by a caller two files away.

## Semver

#961 adds a `throw` on input that previously returned, and changes an existing error message. Minor, not a patch.

## Follow-up, not in this PR

An audit of the remaining Node-only APIs found that `src/utils/merkletree.ts` also requires the `Buffer` global, on a path every criteria order goes through, and that `merkletreejs` does `require("buffer")` in the module graph of every `Seaport` consumer. That work touches the merkle path and belongs in its own PR rather than here.

`npm run build`, `npm run lint` (tsc and Biome), and `npm test` all clean. 192 passing.
