### PR TITLE
fix: reject criteria-based tips instead of building an unresolvable order

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -379,6 +379,8 @@ export function fulfillStandardOrder(
     >
   >
 > {
+  assertNoCriteriaTips(tips)
+
   // If we are supplying units to fill, we adjust the order by the minimum of the amount to fill and
   // the remaining order left to be fulfilled
   const orderWithAdjustedFills = unitsToFill
@@ -599,6 +601,8 @@ export function fulfillAvailableOrders({
     ContractMethodReturnType<SeaportContract, "fulfillAvailableAdvancedOrders">
   >
 > {
+  ordersMetadata.forEach(({ tips }) => assertNoCriteriaTips(tips))
+
   const sanitizedOrdersMetadata = ordersMetadata.map(orderMetadata => ({
     ...orderMetadata,
     order: validateAndSanitizeFromOrderStatus(
@@ -919,6 +923,28 @@ export function generateFulfillOrdersFulfillments(
     considerationFulfillments: Object.values(
       considerationAggregatedFulfillments,
     ),
+  }
+}
+
+/**
+ * Rejects criteria-based tips.
+ *
+ * Tips are appended to the submitted order's consideration array, but criteria
+ * resolvers are generated from the order alone, so a criteria-based tip is
+ * counted when validating that enough criterias were supplied and then never
+ * given a resolver. Seaport rejects the unresolved item with
+ * `UnresolvedConsiderationCriteria`, and if the caller happened to list the
+ * tip's criteria first, the order's own criteria item resolves against the
+ * tip's identifier on the way there. Refuse it here rather than spending gas
+ * to find out.
+ */
+export function assertNoCriteriaTips(tips: ConsiderationItem[]) {
+  if (tips.some(({ itemType }) => isCriteriaItem(itemType))) {
+    throw new Error(
+      "Criteria-based tips are not supported: a tip is appended to the order's " +
+        "consideration but gets no criteria resolver, so Seaport cannot resolve it. " +
+        "Pass a tip with an explicit identifier instead.",
+    )
   }
 }
 

--- a/test/tips.spec.ts
+++ b/test/tips.spec.ts
@@ -3,6 +3,7 @@ import { expect } from "chai"
 import { parseEther } from "ethers"
 import { ItemType } from "../src/constants"
 import type { CreateOrderInput } from "../src/types"
+import { MerkleTree } from "../src/utils/merkletree"
 import { describeWithFixture } from "./utils/setup"
 
 describeWithFixture(
@@ -40,6 +41,43 @@ describeWithFixture(
           },
         ],
       }
+    })
+
+    it("rejects a criteria-based tip instead of building an unresolvable order", async () => {
+      const { seaport, testErc721 } = fixture
+
+      const { executeAllActions } = await seaport.createOrder(
+        erc20Listing,
+        await offerer.getAddress(),
+      )
+      const order = await executeAllActions()
+
+      // The fulfiller has to actually own the tipped NFT, or the balance fetch
+      // reverts NOT_MINTED before the guard is reached.
+      await testErc721.mint(await fulfiller.getAddress(), "42")
+      const tree = new MerkleTree(["42", "43"])
+
+      // A criteria tip is counted when validating that enough criterias were
+      // supplied, but resolvers are generated from the order alone, so without
+      // this guard the SDK hands back a transaction that Seaport reverts with
+      // UnresolvedConsiderationCriteria.
+      await expect(
+        seaport.fulfillOrder({
+          order,
+          accountAddress: await fulfiller.getAddress(),
+          considerationCriteria: [
+            { identifier: "42", proof: tree.getProof("42") },
+          ],
+          tips: [
+            {
+              itemType: ItemType.ERC721,
+              token: await testErc721.getAddress(),
+              criteria: tree.getRoot(),
+              recipient: await tipRecipient.getAddress(),
+            },
+          ],
+        }),
+      ).to.be.rejectedWith("Criteria-based tips are not supported")
     })
 
     it("surfaces the approval a second ERC20 tip needs", async () => {


### PR DESCRIPTION
Follow-up to #972. That PR fixed the fulfiller's balance lookup so tips in a token the order does not carry are actually checked, which removed a wall that had been hiding this.

## The bug

`considerationCriteriaItems` is computed from the tip-appended consideration (`src/utils/fulfill.ts`), so a criteria-based tip counts toward the "you must supply the appropriate criterias" check and sets `hasCriteriaItems`. But `generateCriteriaResolvers` is passed `{ orders: [order] }`, the order alone, so the tip never gets a resolver.

The SDK therefore returns a use case whose exchange action Seaport reverts with `UnresolvedConsiderationCriteria(0, 1)`. And if the caller listed the tip's criteria first, the order's own criteria item resolves against the tip's identifier on the way to that revert.

`fulfillAvailableOrders` has the mismatch inverted as well: `hasCriteriaItems` excludes tips while the per-order criteria-count check includes them.

## Why now

Before #972 this was unreachable: the fulfiller's lookup set had no entry for a tip token, so `findBalanceAndApproval` threw `Checking for balance and approvals for token ... failed` first. That was free and client-side. With the lookup fixed, the next wall is an onchain revert, so a criteria tip now costs gas to discover. This closes that gap.

## Why reject rather than support

`TipInputItem` is `CreateInputItem & { recipient }`, so `{ itemType: ERC721, token, identifiers: [...], recipient }` type-checks today. But nothing can fulfil one, and no caller in our own SDK does. Emitting resolvers for tips would be adding a feature; this PR fixes a regression. Happy to do the supporting version instead if that is preferred, it is a larger change to `generateCriteriaResolvers` and `generateFulfillOrdersFulfillments`.

## Verification

`npm run lint` (tsc and Biome) clean, `npm test` 193 passing.

Tripwire: with both `assertNoCriteriaTips` call sites removed and the test left in place, it fails with

```
AssertionError: expected promise to be rejected with an error including
'Criteria-based tips are not supported' but it was fulfilled with
{ actions: [ { …(6) }, …(2) ], …(2) }
```

That fulfilled value is the doomed transaction being handed back to the caller, which is the behavior this guard removes.

One note on the test: it mints the tipped NFT to the fulfiller first. Without that, the balance fetch in `seaport.ts` reverts `NOT_MINTED` before the guard is reached, and the test would have been passing for the wrong reason.
