### PR TITLE
fix: stop reaching for the Node-only Buffer global on live paths

### DIFF
--- a/src/utils/eip712/Eip712MerkleTree.ts
+++ b/src/utils/eip712/Eip712MerkleTree.ts
@@ -8,25 +8,22 @@ import {
 import { MerkleTree } from "merkletreejs"
 import type { EIP712TypeDefinitions } from "./defaults"
 import { DefaultGetter } from "./defaults"
-import {
-  bufferKeccak,
-  bufferToHex,
-  chunk,
-  fillArray,
-  getRoot,
-  hexToBuffer,
-} from "./utils"
+import { bufferToHex, chunk, fillArray, getRoot, hexToBuffer } from "./utils"
 
 type BulkOrderElements<T> =
   | [T, T]
   | [BulkOrderElements<T>, BulkOrderElements<T>]
 
+// merkletreejs accepts hex strings for leaves, for the fill hash, and as the
+// return of the hash function, and bufferifies them itself. Handing it hex
+// keeps the bulk-order signing path clear of the Node-only `Buffer` global,
+// which browser bundlers do not define. The tree this builds is identical.
 const getTree = (leaves: string[], defaultLeafHash: string) =>
-  new MerkleTree(leaves.map(hexToBuffer), bufferKeccak, {
+  new MerkleTree(leaves, keccak256, {
     complete: true,
     sort: false,
     hashLeaves: false,
-    fillDefaultHash: hexToBuffer(defaultLeafHash),
+    fillDefaultHash: defaultLeafHash,
   })
 
 const encodeProof = (

--- a/src/utils/merkletree.ts
+++ b/src/utils/merkletree.ts
@@ -1,8 +1,12 @@
 import { keccak256, toBeHex } from "ethers"
 import { MerkleTree as MerkleTreeJS } from "merkletreejs"
 
+// Left-pads the identifier to a full 32 byte word before hashing, which is the
+// preimage Seaport verifies criteria proofs against. The padded value stays a
+// hex string rather than becoming a Buffer, so criteria orders can be built in
+// a browser bundle, where the Node-only `Buffer` global is not defined.
 const hashIdentifier = (identifier: string) =>
-  keccak256(Buffer.from(toBeHex(identifier).slice(2).padStart(64, "0"), "hex"))
+  keccak256(`0x${toBeHex(identifier).slice(2).padStart(64, "0")}`)
 
 /**
  * Simple wrapper over the MerkleTree in merkletreejs.

--- a/test/utils/bulk-order-tree.spec.ts
+++ b/test/utils/bulk-order-tree.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai"
+import { ItemType, OrderType } from "../../src/constants"
+import type { OrderComponents } from "../../src/types"
+import { getBulkOrderTree } from "../../src/utils/eip712/bulk-orders"
+import { withoutGlobalBuffer } from "./without-global-buffer"
+
+// getBulkOrderTree backs Seaport.signBulkOrder and Seaport._getBulkMessageToSign.
+// create-bulk-orders.spec.ts covers it end-to-end against a real deployment,
+// which does check the root implicitly (the contract verifies the proof), but
+// only in Node and only for the sizes that spec happens to use. The roots below
+// were captured before the tree switched from Buffer leaves to hex leaves; the
+// encoded proof is what lands in an order's `signature`, so drift here breaks
+// every bulk order signed against the old shape.
+describe("getBulkOrderTree", () => {
+  const orderComponents = (salt: string): OrderComponents => ({
+    offerer: `0x${"11".repeat(20)}`,
+    zone: `0x${"22".repeat(20)}`,
+    offer: [
+      {
+        itemType: ItemType.ERC721,
+        token: `0x${"33".repeat(20)}`,
+        identifierOrCriteria: "7",
+        startAmount: "1",
+        endAmount: "1",
+      },
+    ],
+    consideration: [
+      {
+        itemType: ItemType.NATIVE,
+        token: `0x${"00".repeat(20)}`,
+        identifierOrCriteria: "0",
+        startAmount: "1000",
+        endAmount: "1000",
+        recipient: `0x${"44".repeat(20)}`,
+      },
+    ],
+    orderType: OrderType.FULL_OPEN,
+    startTime: "1",
+    endTime: "2",
+    zoneHash: `0x${"00".repeat(32)}`,
+    salt,
+    totalOriginalConsiderationItems: "1",
+    conduitKey: `0x${"00".repeat(32)}`,
+    counter: "0",
+  })
+
+  const orders = (count: number) =>
+    Array.from({ length: count }, (_, i) => orderComponents(String(i + 1)))
+
+  const signature = `0x${"ab".repeat(64)}`
+
+  // One order and three orders both pad the tree with default leaves, which is
+  // the `fillDefaultHash` option whose type changed.
+  const roots: Record<number, string> = {
+    1: "0xdd5989e38e6f58b2830a0eabdab5d1c43caa7c93a3aa0b5684634b0e9248f9e6",
+    2: "0xe3ead7f64efb41362480141b0eb55141431ef29d986885cfb07d26b552a84e3d",
+    3: "0xaf59e4d3d5a334bc0e1bf01c54cdc129224bbdd19c15fa0e58192b83e01bf0ab",
+    5: "0xb1659c3088ec9176dc46f72f92f1e0c6b7df863ec18b7a3d25f72a294fdb3e9b",
+  }
+
+  for (const count of [1, 2, 3, 5]) {
+    it(`builds the expected root for ${count} order(s)`, () => {
+      expect(getBulkOrderTree(orders(count)).root).to.eq(roots[count])
+    })
+  }
+
+  it("builds the expected proof for a padded tree", () => {
+    expect(getBulkOrderTree(orders(3)).getProof(0).proof).to.deep.eq([
+      "0x4d31f413ed438ef9c8dce741c610a9f664a8844f9f5f7b17c8034b7d543c2620",
+      "0x501081ff3ecfd8e6345c1d62df939fa10fdf8c469b009bc2f0c3d3001813468d",
+    ])
+  })
+
+  it("encodes the proof and signature into the bulk order signature", () => {
+    expect(
+      getBulkOrderTree(orders(3)).getEncodedProofAndSignature(0, signature),
+    ).to.eq(
+      `${signature}000000` +
+        "4d31f413ed438ef9c8dce741c610a9f664a8844f9f5f7b17c8034b7d543c2620" +
+        "501081ff3ecfd8e6345c1d62df939fa10fdf8c469b009bc2f0c3d3001813468d",
+    )
+  })
+
+  it("builds the tree without the Node-only Buffer global", () => {
+    expect(withoutGlobalBuffer(() => getBulkOrderTree(orders(3)).root)).to.eq(
+      roots[3],
+    )
+  })
+
+  it("encodes a bulk order signature without the Node-only Buffer global", () => {
+    const encoded = withoutGlobalBuffer(() =>
+      getBulkOrderTree(orders(3)).getEncodedProofAndSignature(0, signature),
+    )
+
+    expect(encoded).to.eq(
+      `${signature}000000` +
+        "4d31f413ed438ef9c8dce741c610a9f664a8844f9f5f7b17c8034b7d543c2620" +
+        "501081ff3ecfd8e6345c1d62df939fa10fdf8c469b009bc2f0c3d3001813468d",
+    )
+  })
+
+  it("builds the data to sign without the Node-only Buffer global", () => {
+    // getDataToSign is what Seaport.signBulkOrder hands to signTypedData, and
+    // it runs through the same tree construction.
+    const chunks = withoutGlobalBuffer(
+      () => getBulkOrderTree(orders(2)).getDataToSign() as OrderComponents[],
+    )
+
+    expect(chunks).to.have.lengthOf(2)
+    expect(chunks[0].salt).to.eq("1")
+    expect(chunks[1].salt).to.eq("2")
+  })
+})

--- a/test/utils/merkletree.spec.ts
+++ b/test/utils/merkletree.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai"
+import { MerkleTree } from "../../src/utils/merkletree"
+import { withoutGlobalBuffer } from "./without-global-buffer"
+
+// This is the criteria path. `mapInputItemToOfferItem` turns an item's
+// `identifiers` into a merkle root through this class, so every collection and
+// trait offer built through `createOrder` runs through it. It is covered
+// end-to-end by criteria-based.spec.ts against a real Seaport deployment, but
+// only there, which leaves two properties unpinned: the exact leaf preimage, and
+// whether it works anywhere other than Node.
+describe("criteria MerkleTree", () => {
+  const maxUint256 =
+    "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+  const identifiers = ["1", "2", "3", "0", "255", maxUint256]
+
+  // Captured from the Buffer-based implementation. Seaport verifies criteria
+  // proofs onchain against `keccak256` of the identifier left-padded to a full
+  // 32 byte word, so these values are consensus-critical: changing the preimage
+  // silently invalidates every criteria order already signed against a root.
+  const root =
+    "0x72279d7180f70428b270f70e7db86c6109f30ba6bb3701d6f05467508a4d09c7"
+
+  it("hashes an identifier as a full 32 byte word", () => {
+    // A one-leaf tree's root is the leaf, so this pins the preimage directly:
+    // keccak256(0x00..01), not keccak256(0x01) and not keccak256("1").
+    expect(new MerkleTree(["1"]).getRoot()).to.eq(
+      "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
+    )
+  })
+
+  it("builds the expected root over an odd number of identifiers", () => {
+    expect(new MerkleTree(identifiers).getRoot()).to.eq(root)
+  })
+
+  it("builds the expected proof for a mid-tree identifier", () => {
+    expect(new MerkleTree(identifiers).getProof("2")).to.deep.eq([
+      "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+      "0x4c5abe0e7a614c3823af05b9adc2c09c065a9f60b1e95721d337f7ae47b71a21",
+      "0x95d8e4ad618b6fc07daabb3e0e2ba86cb9d26270df3280ce425f1e491cb75356",
+    ])
+  })
+
+  it("builds the expected proof for the maximum uint256 identifier", () => {
+    expect(new MerkleTree(identifiers).getProof(maxUint256)).to.deep.eq([
+      "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
+      "0xb55518d7cf87ba2deb7ded26fc6150b73b33fac753629045863fded7c75158bd",
+      "0x95d8e4ad618b6fc07daabb3e0e2ba86cb9d26270df3280ce425f1e491cb75356",
+    ])
+  })
+
+  it("returns the '0' sentinel for an empty tree", () => {
+    expect(new MerkleTree([]).getRoot()).to.eq("0")
+  })
+
+  it("builds a root without the Node-only Buffer global", () => {
+    expect(
+      withoutGlobalBuffer(() => new MerkleTree(identifiers).getRoot()),
+    ).to.eq(root)
+  })
+
+  it("builds a proof without the Node-only Buffer global", () => {
+    expect(
+      withoutGlobalBuffer(() => new MerkleTree(identifiers).getProof("3")),
+    ).to.deep.eq([
+      "0xe08ec2af2cfc251225e1968fd6ca21e4044f129bffa95bac3503be8bdb30a367",
+      "0xbef008cc1c3168b77620ea11b970aafc3ee4fcd8598bd65dd2eee43862d9c6ac",
+    ])
+  })
+})

--- a/test/utils/without-global-buffer.ts
+++ b/test/utils/without-global-buffer.ts
@@ -1,0 +1,21 @@
+/**
+ * Runs `fn` with the Node-only `Buffer` global removed, which is what a browser
+ * bundle sees. Bundlers can alias the `buffer` *module* to a polyfill, which is
+ * what keeps merkletreejs working, but none of them define `globalThis.Buffer`,
+ * so any library code reaching for the global throws `ReferenceError` in a page
+ * while passing every test in Node.
+ *
+ * `fn` must be synchronous. The global is missing for the whole call, so letting
+ * the event loop run in the middle would expose unrelated code to its absence.
+ */
+export const withoutGlobalBuffer = <T>(fn: () => T): T => {
+  const global = globalThis as { Buffer?: unknown }
+  const saved = global.Buffer
+
+  delete global.Buffer
+  try {
+    return fn()
+  } finally {
+    global.Buffer = saved
+  }
+}


### PR DESCRIPTION
Follow-up to #972. That PR took the `Buffer` removal from `generateRandomSalt`, and an audit of the rest of the surface found two more sites on paths reachable from the public `Seaport` class.

## What was broken

| Site | Reached from | Effect in a browser |
|---|---|---|
| `merkletree.ts` `hashIdentifier` | `mapInputItemToOfferItem`, so every criteria-based item: collection and trait offers | `ReferenceError: Buffer is not defined` |
| `eip712/Eip712MerkleTree.ts` `getTree` | `signBulkOrder`, `createBulkOrders` | same |

`Buffer` is a Node global that bundlers do not define, so both passed every test in Node and threw in a page. Reproduced against unmodified main both by deleting the global from the published CJS `lib` and by executing a real esbuild browser bundle:

```
FAIL  new MerkleTree(['1','2']).getRoot()            -> ReferenceError: Buffer is not defined
FAIL  mapInputItemToOfferItem w/ identifiers         -> ReferenceError: Buffer is not defined
FAIL  getBulkOrderTree([...]).root                   -> ReferenceError: Buffer is not defined
```

## Why this is safe

merkletreejs accepts hex strings for leaves, for the fill hash, and as the return of the hash function, and bufferifies them itself, so the tree it builds is identical. Since this is criteria-proof and bulk-signing data, "identical" needed proving rather than asserting: roots and proofs were captured before and after the change for identifiers `["1","2","3","0","255", 2**256-1]`, covering an odd leaf count and both boundary identifiers, plus the bulk-order root, proof, and encoded signature for 1, 2, 3 and 5 components. Byte-identical throughout.

Those goldens are pinned as tests now, which is why they pass on both sides of each tripwire below. They are regression guards, not tripwires.

`hashIdentifier` keeps the `padStart` form rather than the tidier `toBeHex(identifier, 32)` on purpose: the latter throws above `2**256 - 1` where the old code silently hashed a 33-byte preimage, so `padStart` keeps every input byte-identical, valid or not.

## Verification

`npm run build`, `npm run lint` (tsc and Biome), `npm test` all clean at 209 passing.

Tripwires, each reverting one hunk with the tests left in place:

| Reverted | Result |
|---|---|
| `hashIdentifier` | 2 failing, both named for it, `ReferenceError: Buffer is not defined` |
| `getTree` | 3 failing, all named for it, same error |

## This does not make the library isomorphic

Being explicit, since the PR this follows up on claimed otherwise. Remaining blockers:

1. `merkletreejs` does `require("buffer")` and sits in the module graph of every `Seaport` consumer, criteria or not, because `order.ts` imports `./merkletree` at module scope. An esbuild `--platform=browser` build fails with four unresolved-module errors before any global matters. Browser consumers need a `buffer` alias regardless.
2. The five exported helpers in `eip712/utils.ts` still require the global. They are unreachable from live paths after this change, reachable only via `Eip712MerkleTree.getBulkOrderHash()`, which nothing calls and which throws its own self-check error for every tree size tested. Left alone deliberately: converting them changes five exported signatures for no reachable gain, and it deserves its own decision about whether to delete `getBulkOrderHash` or fix it.
3. The package is CJS-only with no `exports` map, so a bundler cannot select a browser or ESM condition for it.

What this PR buys precisely: seaport-js's own code no longer touches the `Buffer` global on any path reachable from the `Seaport` class. `createOrder` with plain and criteria items, `createBulkOrders`, and `signBulkOrder` all run with `globalThis.Buffer` deleted.

## Incidental finding, not addressed here

`Eip712MerkleTree.getBulkOrderHash()` throws `expected derived bulk order hash to match` for every tree size tested (1, 2, 3, 5) on unmodified main. It appears to be dead code that does not work. Worth its own issue.
