### PR TITLE
fix: approve the batch total for a shared ERC20, not one order's share

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -672,6 +672,11 @@ export function fulfillAvailableOrders({
 
   let totalNativeAmount = 0n
   const totalInsufficientApprovals: InsufficientApprovals = []
+  // What the fulfiller owes across the WHOLE batch, per lowercased token and
+  // identifier. Each order's own requirement is checked separately below, but
+  // an ERC20 approval is one allowance shared by every order in the batch, so
+  // the amount to approve is this total rather than any single order's share.
+  const cumulativeFulfillerAmounts: Record<string, Record<string, bigint>> = {}
   const criteriaOffersAndConsiderations = sanitizedOrdersMetadata
     .flatMap(orderMetadata => [
       orderMetadata.order.parameters.offer,
@@ -719,13 +724,25 @@ export function fulfillAvailableOrders({
         isConsiderationItem: true,
       }
 
+      const summedConsideration = getSummedTokenAndIdentifierAmounts({
+        items: considerationIncludingTips,
+        criterias: considerationCriteria,
+        timeBasedItemParams,
+      })
+
       totalNativeAmount =
         totalNativeAmount +
-        (getSummedTokenAndIdentifierAmounts({
-          items: considerationIncludingTips,
-          criterias: considerationCriteria,
-          timeBasedItemParams,
-        })[ethers.ZeroAddress]?.["0"] ?? 0n)
+        (summedConsideration[ethers.ZeroAddress]?.["0"] ?? 0n)
+
+      for (const [token, identifierToAmount] of Object.entries(
+        summedConsideration,
+      )) {
+        for (const [identifier, amount] of Object.entries(identifierToAmount)) {
+          cumulativeFulfillerAmounts[token] ??= {}
+          cumulativeFulfillerAmounts[token][identifier] =
+            (cumulativeFulfillerAmounts[token][identifier] ?? 0n) + amount
+        }
+      }
 
       const insufficientApprovals = validateStandardFulfillBalancesAndApprovals(
         {
@@ -764,8 +781,25 @@ export function fulfillAvailableOrders({
 
   overrides = { ...overrides, value: totalNativeAmount }
 
+  // An approval is deduped to one action per token and operator, and with
+  // exactApproval that action approves `requiredApprovedAmount`. Left as the
+  // first order's share it under-approves the batch and the fulfillment reverts.
+  // Raise it to the batch total, never lower it: an order whose allowance
+  // already covers it contributes no entry here at all, so summing the entries
+  // that are present would still undercount.
+  const approvalsForBatch = totalInsufficientApprovals.map(approval => {
+    const cumulative =
+      cumulativeFulfillerAmounts[approval.token.toLowerCase()]?.[
+        approval.identifierOrCriteria
+      ]
+    return cumulative !== undefined &&
+      cumulative > approval.requiredApprovedAmount
+      ? { ...approval, requiredApprovedAmount: cumulative }
+      : approval
+  })
+
   const approvalActions = getApprovalActions(
-    totalInsufficientApprovals,
+    approvalsForBatch,
     exactApproval,
     signer,
   )

--- a/test/fulfill-orders.spec.ts
+++ b/test/fulfill-orders.spec.ts
@@ -1237,6 +1237,84 @@ describeWithFixture(
           await secondOfferer.getAddress(),
         )
       })
+
+      it("approves the batch total for one ERC20, not the first order's share", async () => {
+        const { seaport, testErc721, testErc20 } = fixture
+
+        // Two listings priced in the same ERC20, 10 and 20, so the batch needs 30.
+        await testErc721.mint(await offerer.getAddress(), nftId)
+        await testErc721.mint(await secondOfferer.getAddress(), nftId2)
+        await testErc20.mint(
+          await fulfiller.getAddress(),
+          parseEther("30").toString(),
+        )
+
+        const listing = async (
+          seller: HardhatEthersSigner,
+          identifier: string,
+          price: string,
+        ) =>
+          (
+            await seaport.createOrder(
+              {
+                offer: [
+                  {
+                    itemType: ItemType.ERC721,
+                    token: await testErc721.getAddress(),
+                    identifier,
+                  },
+                ],
+                consideration: [
+                  {
+                    amount: parseEther(price).toString(),
+                    token: await testErc20.getAddress(),
+                    recipient: await seller.getAddress(),
+                  },
+                ],
+              },
+              await seller.getAddress(),
+            )
+          ).executeAllActions()
+
+        const firstOrder = await listing(offerer, nftId, "10")
+        const secondOrder = await listing(secondOfferer, nftId2, "20")
+
+        const { actions } = await seaport.fulfillOrders({
+          fulfillOrderDetails: [{ order: firstOrder }, { order: secondOrder }],
+          accountAddress: await fulfiller.getAddress(),
+          exactApproval: true,
+        })
+
+        const erc20Address = await testErc20.getAddress()
+        const erc20Approvals = actions.filter(
+          (action): action is ApprovalAction =>
+            action.type === "approval" && action.token === erc20Address,
+        )
+        // One allowance is shared by the whole batch, so one action is correct.
+        expect(erc20Approvals.length).to.equal(1)
+
+        for (const action of actions.filter(a => a.type === "approval")) {
+          await action.transactionMethods.transact()
+        }
+
+        // The allowance has to cover 10 + 20, not just the first order's 10.
+        // Read the spender off the action rather than recomputing the conduit.
+        expect(
+          await testErc20.allowance(
+            await fulfiller.getAddress(),
+            erc20Approvals[0].operator,
+          ),
+        ).to.equal(parseEther("30"))
+
+        await actions[actions.length - 1].transactionMethods.transact()
+
+        expect(await testErc721.ownerOf(nftId)).to.equal(
+          await fulfiller.getAddress(),
+        )
+        expect(await testErc721.ownerOf(nftId2)).to.equal(
+          await fulfiller.getAddress(),
+        )
+      })
     })
     // TODO
     describe("Special use cases", () => {


### PR DESCRIPTION
`fulfillOrders` with `exactApproval: true` under-approves whenever two orders in a batch are priced in the same ERC20.

## The mechanism

`addApprovalIfNeeded` dedups approvals on `token:operator`, keeping the first entry. `getApprovalActions` then issues `approve(operator, requiredApprovedAmount)` from that single entry. So for two listings priced 10 and 20 in the same token, the SDK emits one approval for 10 and the fulfillment reverts with `panic 0x11` on the arithmetic.

The default path is unaffected: without `exactApproval` the approval is `MAX_INT`.

## Why summing the entries would not fix it

This was the trap worth avoiding. `requiredAmount` in `getInsufficientBalanceAndApprovalAmounts` is an order's **full** requirement, not its shortfall, and an order whose allowance already covers it is filtered out before it ever becomes an entry. So with a partial pre-existing allowance, one order drops out of the list entirely and summing what remains still falls short.

The fix therefore accumulates the requirement from each order's summed consideration, which is the same map already being computed for `msg.value`, and raises each approval to that total. It only ever raises, never lowers.

Token keys are matched lowercased, because the summation map lowercases to merge two casings of one address while `InsufficientApprovals.token` deliberately reports the order's own casing. That distinction is already documented in `balanceAndApprovalCheck.ts` and a previous fix existed for getting it wrong.

## Verification

`npm run build`, `npm run lint` (tsc and Biome), and `npm test` all clean at 210 passing.

Tripwire: reverting only the raise step, with the test left in place, fails on the assertion it is named for:

```
AssertionError: expected 10000000000000000000 to equal 30000000000000000000
```

That is the under-approval exactly. No other test changes, so the existing ERC721 per-identifier exact-approval test is undisturbed.

## Related, not in this PR

Two findings from the same audit are deliberately held back:

`fulfillOrders` also checks the fulfiller's balance per order against the same un-decremented balances, so a fulfiller holding 25 can be handed a transaction needing 30 with no error at all. Making it throw is very likely right, but the per-order check credits offer items the fulfiller receives, and an order in a batch can offer ERC20, so a naive cumulative check would ignore incoming currency and falsely reject batches that actually balance. A false throw blocking a working batch is worse than the current silence, so that needs its own analysis and its own does-not-false-throw test.

`createBulkOrders` has this same root cause on the offerer side. A clean fix needs `_formatOrder` to return its insufficient approvals so the check can be cumulative, which is order-creation surface rather than the fulfill path.
