### PR TITLE
fix: drop unfillable orders from a batch instead of failing the batch

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -558,6 +558,23 @@ export function validateAndSanitizeFromOrderStatus(
   return order
 }
 
+/**
+ * Whether an order can still be filled at all.
+ *
+ * Mirrors the two rejections in `validateAndSanitizeFromOrderStatus`, which
+ * throws so that a single-order fulfill fails loudly. A batch fulfill cannot
+ * use that: `fulfillAvailableAdvancedOrders` skips orders it cannot fill and
+ * settles the rest, so one stale order in the batch has to be dropped rather
+ * than take the whole call down with it.
+ */
+export function isOrderFulfillable({
+  isCancelled,
+  totalFilled,
+  totalSize,
+}: OrderStatus): boolean {
+  return !isCancelled && !(totalSize > 0n && totalFilled / totalSize === 1n)
+}
+
 export type FulfillOrdersMetadata = {
   order: Order
   unitsToFill?: BigNumberish
@@ -603,13 +620,24 @@ export function fulfillAvailableOrders({
 > {
   ordersMetadata.forEach(({ tips }) => assertNoCriteriaTips(tips))
 
-  const sanitizedOrdersMetadata = ordersMetadata.map(orderMetadata => ({
-    ...orderMetadata,
-    order: validateAndSanitizeFromOrderStatus(
-      orderMetadata.order,
-      orderMetadata.orderStatus,
-    ),
-  }))
+  // Drop the orders that cannot be filled instead of throwing on the first one.
+  // Every array built below is indexed by position in this list, so the
+  // fulfillments and criteria resolvers are derived from it too.
+  const sanitizedOrdersMetadata = ordersMetadata
+    .filter(({ orderStatus }) => isOrderFulfillable(orderStatus))
+    .map(orderMetadata => ({
+      ...orderMetadata,
+      order: validateAndSanitizeFromOrderStatus(
+        orderMetadata.order,
+        orderMetadata.orderStatus,
+      ),
+    }))
+
+  if (sanitizedOrdersMetadata.length === 0) {
+    throw new Error(
+      "None of the orders can be fulfilled: every one is already filled or cancelled.",
+    )
+  }
 
   const adjustTips = (orderMetadata: {
     order: Order
@@ -798,7 +826,7 @@ export function fulfillAvailableOrders({
   )
 
   const { offerFulfillments, considerationFulfillments } =
-    generateFulfillOrdersFulfillments(ordersMetadata)
+    generateFulfillOrdersFulfillments(sanitizedOrdersMetadata)
 
   const exchangeAction = {
     type: "exchange",
@@ -810,11 +838,11 @@ export function fulfillAvailableOrders({
         advancedOrdersWithTips,
         hasCriteriaItems
           ? generateCriteriaResolvers({
-              orders: ordersMetadata.map(({ order }) => order),
-              offerCriterias: ordersMetadata.map(
+              orders: sanitizedOrdersMetadata.map(({ order }) => order),
+              offerCriterias: sanitizedOrdersMetadata.map(
                 ({ offerCriteria }) => offerCriteria,
               ),
-              considerationCriterias: ordersMetadata.map(
+              considerationCriterias: sanitizedOrdersMetadata.map(
                 ({ considerationCriteria }) => considerationCriteria,
               ),
             })

--- a/test/fulfill-orders-availability.spec.ts
+++ b/test/fulfill-orders-availability.spec.ts
@@ -1,0 +1,124 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { CreateOrderInput, OrderWithCounter } from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a user I want a batch fulfill to survive one unfillable order",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let fulfiller: HardhatEthersSigner
+    let firstOrder: OrderWithCounter
+    let secondOrder: OrderWithCounter
+
+    const firstNftId = "1"
+    const secondNftId = "2"
+    const price = parseEther("1")
+
+    const listingFor = async (nftId: string): Promise<CreateOrderInput> => ({
+      startTime: "0",
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: await fixture.testErc721.getAddress(),
+          identifier: nftId,
+        },
+      ],
+      consideration: [
+        { amount: price.toString(), recipient: await offerer.getAddress() },
+      ],
+    })
+
+    beforeEach(async () => {
+      const { ethers, seaport, testErc721 } = fixture
+      ;[offerer, , fulfiller] = await ethers.getSigners()
+
+      await testErc721.mint(await offerer.getAddress(), firstNftId)
+      await testErc721.mint(await offerer.getAddress(), secondNftId)
+
+      firstOrder = await (
+        await seaport.createOrder(await listingFor(firstNftId))
+      ).executeAllActions()
+      secondOrder = await (
+        await seaport.createOrder(await listingFor(secondNftId))
+      ).executeAllActions()
+    })
+
+    it("drops a cancelled order and still fulfills the other", async () => {
+      const { seaport, testErc721 } = fixture
+
+      await (
+        await seaport
+          .cancelOrders([firstOrder.parameters], await offerer.getAddress())
+          .transact()
+      ).wait()
+
+      const { actions } = await seaport.fulfillOrders({
+        fulfillOrderDetails: [{ order: firstOrder }, { order: secondOrder }],
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const fulfillAction = actions[actions.length - 1]
+
+      // Only the surviving order is paid for.
+      const transaction =
+        await fulfillAction.transactionMethods.buildTransaction()
+      expect(transaction.value).to.eq(price)
+
+      await (await fulfillAction.transactionMethods.transact()).wait()
+
+      expect(await testErc721.ownerOf(secondNftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+      expect(await testErc721.ownerOf(firstNftId)).to.eq(
+        await offerer.getAddress(),
+      )
+    })
+
+    it("drops an already filled order and still fulfills the other", async () => {
+      const { seaport, testErc721 } = fixture
+
+      await (
+        await seaport.fulfillOrder({
+          order: firstOrder,
+          accountAddress: await fulfiller.getAddress(),
+        })
+      ).executeAllActions()
+
+      const { actions } = await seaport.fulfillOrders({
+        fulfillOrderDetails: [{ order: firstOrder }, { order: secondOrder }],
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      await (
+        await actions[actions.length - 1].transactionMethods.transact()
+      ).wait()
+
+      expect(await testErc721.ownerOf(secondNftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+    })
+
+    it("still reports when nothing in the batch can be filled", async () => {
+      const { seaport } = fixture
+
+      await (
+        await seaport
+          .cancelOrders(
+            [firstOrder.parameters, secondOrder.parameters],
+            await offerer.getAddress(),
+          )
+          .transact()
+      ).wait()
+
+      await expect(
+        seaport.fulfillOrders({
+          fulfillOrderDetails: [{ order: firstOrder }, { order: secondOrder }],
+          accountAddress: await fulfiller.getAddress(),
+        }),
+      ).to.be.rejectedWith("None of the orders can be fulfilled")
+    })
+  },
+)


### PR DESCRIPTION
## Problem

`fulfillOrders` is documented as best effort — "Orders that fail will not revert the whole transaction" — and `fulfillAvailableAdvancedOrders` does behave that way on chain, skipping what it cannot fill and settling the rest.

The SDK never gets there. `fulfillAvailableOrders` maps every order through `validateAndSanitizeFromOrderStatus`, which throws on the first cancelled or fully filled one, so a single stale order takes the whole call down before a transaction is built.

Cancelling one of two listings and passing both:

```
contract  fulfillAvailableAdvancedOrders -> availableOrders [false, true]
SDK       fulfillOrders                  -> throws "The order you are trying to fulfill is cancelled"
```

The contract settles the second listing. The caller gets nothing. That is the ordinary case for an aggregator sweeping listings, where orders go stale between reading them and filling them — most of the reason to reach for this method in the first place.

## Fix

Filter the unfillable orders out of the batch and build the call from what is left.

Everything downstream is indexed by position in that list, so `generateFulfillOrdersFulfillments` and `generateCriteriaResolvers` now read the filtered list too. They were reading the unfiltered one, which only lined up because nothing was ever dropped; once orders can be dropped it would have pointed fulfillments at the wrong ones.

If nothing survives the filter it still throws, since there is no transaction left to send.

`fulfillOrder` is untouched. There is no batch to fall back on for a single order, so failing loudly is right there.

## Test

`test/fulfill-orders-availability.spec.ts` covers three cases: a cancelled order dropped while the other settles and `value` covers only the survivor, the same for an order that was already filled, and an all-unfillable batch still raising.

Revert the `fulfill.ts` change and all three stop at "The order you are trying to fulfill is cancelled".
