### PR TITLE
fix: cap unitsToFill at what is left of a partially filled order

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -381,6 +381,10 @@ export function fulfillStandardOrder(
 > {
   assertNoCriteriaTips(tips)
 
+  if (unitsToFill) {
+    unitsToFill = clampUnitsToRemaining(unitsToFill, { totalFilled, totalSize })
+  }
+
   // If we are supplying units to fill, we adjust the order by the minimum of the amount to fill and
   // the remaining order left to be fulfilled
   const orderWithAdjustedFills = unitsToFill
@@ -605,6 +609,12 @@ export function fulfillAvailableOrders({
 
   const sanitizedOrdersMetadata = ordersMetadata.map(orderMetadata => ({
     ...orderMetadata,
+    unitsToFill: orderMetadata.unitsToFill
+      ? clampUnitsToRemaining(
+          orderMetadata.unitsToFill,
+          orderMetadata.orderStatus,
+        )
+      : orderMetadata.unitsToFill,
     order: validateAndSanitizeFromOrderStatus(
       orderMetadata.order,
       orderMetadata.orderStatus,
@@ -946,6 +956,32 @@ export function assertNoCriteriaTips(tips: ConsiderationItem[]) {
         "Pass a tip with an explicit identifier instead.",
     )
   }
+}
+
+/**
+ * Caps a requested fill at what is left of a partially filled order.
+ *
+ * Seaport does this itself: asking for 8 of 10 units when only 4 remain
+ * transfers 4 and closes the order. Deriving amounts from the raw request
+ * instead describes a fill that will never happen -- the offer side is sized
+ * for units the offerer no longer holds, so the balance check rejects an order
+ * the contract would have settled.
+ *
+ * Only applies once an order is partially filled. A request larger than the
+ * order was ever divisible into is a different thing entirely, and
+ * getAdvancedOrderNumeratorDenominator still rejects it.
+ */
+export const clampUnitsToRemaining = (
+  unitsToFill: BigNumberish,
+  { totalFilled, totalSize }: Pick<OrderStatus, "totalFilled" | "totalSize">,
+): BigNumberish => {
+  if (totalFilled === 0n) {
+    return unitsToFill
+  }
+
+  const remaining = totalSize - totalFilled
+
+  return BigInt(unitsToFill) > remaining ? remaining : unitsToFill
 }
 
 export const getAdvancedOrderNumeratorDenominator = (

--- a/test/fulfill-remaining-units.spec.ts
+++ b/test/fulfill-remaining-units.spec.ts
@@ -1,0 +1,102 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { CreateOrderInput, OrderWithCounter } from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a user I want to fill what is left of an order someone else partly took",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let fulfiller: HardhatEthersSigner
+    let order: OrderWithCounter
+    let orderHash: string
+
+    const nftId = "1"
+    const totalUnits = 10
+    const price = parseEther("10")
+
+    beforeEach(async () => {
+      const { ethers, seaport, testErc1155 } = fixture
+      ;[offerer, , fulfiller] = await ethers.getSigners()
+
+      await testErc1155.mint(await offerer.getAddress(), nftId, totalUnits)
+
+      const input: CreateOrderInput = {
+        startTime: "0",
+        allowPartialFills: true,
+        offer: [
+          {
+            itemType: ItemType.ERC1155,
+            token: await testErc1155.getAddress(),
+            identifier: nftId,
+            amount: String(totalUnits),
+          },
+        ],
+        consideration: [
+          { amount: price.toString(), recipient: await offerer.getAddress() },
+        ],
+      }
+
+      order = await (await seaport.createOrder(input)).executeAllActions()
+      orderHash = seaport.getOrderHash(order.parameters)
+
+      // Someone takes 6 of the 10 units first.
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        unitsToFill: 6,
+        accountAddress: await fulfiller.getAddress(),
+      })
+      for (const action of actions) {
+        await (await action.transactionMethods.transact()).wait()
+      }
+    })
+
+    it("fills the remaining units when asked for more than are left", async () => {
+      const { seaport, testErc1155 } = fixture
+
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        unitsToFill: 8, // only 4 remain
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const fulfillAction = actions[actions.length - 1]
+
+      // Four units at 1 ETH each, not the eight that were asked for.
+      const transaction =
+        await fulfillAction.transactionMethods.buildTransaction()
+      expect(transaction.value).to.eq(parseEther("4"))
+
+      await (await fulfillAction.transactionMethods.transact()).wait()
+
+      expect(
+        await testErc1155.balanceOf(await fulfiller.getAddress(), nftId),
+      ).to.eq(BigInt(totalUnits))
+
+      const status = await seaport.getOrderStatus(orderHash)
+      expect(status.totalFilled).to.eq(status.totalSize)
+    })
+
+    it("does the same through fulfillOrders", async () => {
+      const { seaport, testErc1155 } = fixture
+
+      const { actions } = await seaport.fulfillOrders({
+        fulfillOrderDetails: [{ order, unitsToFill: 8 }],
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const fulfillAction = actions[actions.length - 1]
+      const transaction =
+        await fulfillAction.transactionMethods.buildTransaction()
+      expect(transaction.value).to.eq(parseEther("4"))
+
+      await (await fulfillAction.transactionMethods.transact()).wait()
+
+      expect(
+        await testErc1155.balanceOf(await fulfiller.getAddress(), nftId),
+      ).to.eq(BigInt(totalUnits))
+    })
+  },
+)

--- a/test/fulfill-units.spec.ts
+++ b/test/fulfill-units.spec.ts
@@ -1,6 +1,9 @@
 import { expect } from "chai"
 import type { Order } from "../src/types"
-import { getAdvancedOrderNumeratorDenominator } from "../src/utils/fulfill"
+import {
+  clampUnitsToRemaining,
+  getAdvancedOrderNumeratorDenominator,
+} from "../src/utils/fulfill"
 import { getMaximumSizeForOrder } from "../src/utils/item"
 
 // Builds a minimal Order shaped just enough for the amount-based helpers under
@@ -67,5 +70,37 @@ describe("units-to-fill validation (getAdvancedOrderNumeratorDenominator)", () =
     expect(() => getAdvancedOrderNumeratorDenominator(feedErc721, 2)).to.throw(
       "Cannot fill 2 units: this order is only divisible into 1 unit(s)",
     )
+  })
+})
+
+// Seaport caps a fill at whatever is left of a partially filled order, so the
+// SDK has to size its amounts against the same number. Status here is already
+// scaled to the order's max units by scaleOrderStatusToMaxUnits.
+describe("clamping units to what remains", () => {
+  it("leaves a request that fits inside the remainder alone", () => {
+    expect(clampUnitsToRemaining(3, { totalFilled: 6n, totalSize: 10n })).to.eq(
+      3,
+    )
+  })
+
+  it("caps a request that runs past the remainder", () => {
+    expect(clampUnitsToRemaining(8, { totalFilled: 6n, totalSize: 10n })).to.eq(
+      4n,
+    )
+  })
+
+  it("caps to the remainder when the whole rest is requested", () => {
+    expect(
+      clampUnitsToRemaining(10, { totalFilled: 6n, totalSize: 10n }),
+    ).to.eq(4n)
+  })
+
+  it("leaves an untouched order alone so divisibility is still enforced", () => {
+    // totalFilled 0 means nothing has been taken yet; an oversized request
+    // there is a caller error and stays with
+    // getAdvancedOrderNumeratorDenominator to reject.
+    expect(
+      clampUnitsToRemaining(99, { totalFilled: 0n, totalSize: 10n }),
+    ).to.eq(99)
   })
 })


### PR DESCRIPTION
The comment sitting over this code already says what should happen — the order is adjusted by "the minimum of the amount to fill and the remaining order left to be fulfilled". No minimum is ever taken. `unitsToFill` reaches `mapOrderAmountsFromUnitsToFill` and `getAdvancedOrderNumeratorDenominator` exactly as the caller passed it.

Seaport does take that minimum. On an order with 4 of 10 units left, a request for 8 transfers 4 and closes the order out. The SDK meanwhile sizes the offer side for 8 units the offerer no longer holds, and its own balance check stops the fill:

```
The offerer does not have the amount needed to create or fulfill.
```

Which reads as the offerer's problem. The offerer is fine — the request just ran past the remainder. Send the same fill straight to the contract and it settles.

**Repro** — mint 10 units, let someone fill 6, then ask for 8:

| | |
|---|---|
| contract, `fulfillAdvancedOrder` 8/10 | transfers 4, order now fully filled |
| SDK, `unitsToFill: 8` | throws before building anything |

**Patch** — take the minimum, in the single and batch paths both. Amounts, tips and numerator/denominator then describe a fill that will really happen, and `value` covers the units that actually move.

I went with capping rather than a new error because the contract caps, and because `fulfillOrder` with no `unitsToFill` at all already fills whatever is left — capping keeps an explicit request consistent with that. Worth a second opinion if you'd rather it raised.

This only kicks in once an order is partially filled. Asking for more units than the order was ever divisible into is a caller mistake rather than a race, and `getAdvancedOrderNumeratorDenominator` still rejects that with the message it has today — there's a test pinning it.

**Tests** — four unit cases on the cap in `fulfill-units.spec.ts`, and `fulfill-remaining-units.spec.ts` drives the real thing end to end on both paths, asserting `value` is 4 ETH rather than 8 and that the fulfiller ends up holding all 10 units. Both integration cases fail on `main` with the error above. Suite 215.
