### PR TITLE
fix: leave out a fee item that rounds down to zero

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -363,14 +363,24 @@ export class Seaport {
     const considerationItemsWithFees = [
       ...deductFees(considerationItems, fees),
       ...(currencies.length
-        ? (fees?.map(fee =>
-            feeToConsiderationItem({
-              fee,
-              token: currencies[0].token,
-              baseAmount: totalCurrencyAmount.startAmount,
-              baseEndAmount: totalCurrencyAmount.endAmount,
-            }),
-          ) ?? [])
+        ? (fees
+            ?.map(fee =>
+              feeToConsiderationItem({
+                fee,
+                token: currencies[0].token,
+                baseAmount: totalCurrencyAmount.startAmount,
+                baseEndAmount: totalCurrencyAmount.endAmount,
+              }),
+            )
+            // A fee small enough to floor to zero on both ends carries nothing,
+            // and Seaport rejects a zero-amount item with MissingItemAmount, so
+            // including it would leave the order permanently unfulfillable. An
+            // item that is only zero at one end still pays over the rest of its
+            // range and is kept.
+            .filter(
+              ({ startAmount, endAmount }) =>
+                BigInt(startAmount) > 0n || BigInt(endAmount) > 0n,
+            ) ?? [])
         : []),
     ]
 

--- a/test/create-order.spec.ts
+++ b/test/create-order.spec.ts
@@ -1102,5 +1102,100 @@ describeWithFixture(
         parseEther("9.75"),
       )
     })
+
+    // multiplyBasisPoints floors, so a small enough price makes the fee item come
+    // out as zero. Seaport rejects a zero-amount item with MissingItemAmount, so
+    // such an item would leave the signed order impossible to fill.
+    describe("a fee that rounds down to nothing", () => {
+      const nftId = "1"
+
+      const listingFor = async (
+        amount: string,
+        basisPoints: number,
+        endAmount?: string,
+      ): Promise<CreateOrderInput> => {
+        const { ethers, testErc721 } = fixture
+        const [offerer, zone] = await ethers.getSigners()
+
+        return {
+          startTime: "0",
+          offer: [
+            {
+              itemType: ItemType.ERC721,
+              token: await testErc721.getAddress(),
+              identifier: nftId,
+            },
+          ],
+          consideration: [
+            {
+              amount,
+              ...(endAmount ? { endAmount } : {}),
+              recipient: await offerer.getAddress(),
+            },
+          ],
+          fees: [{ recipient: await zone.getAddress(), basisPoints }],
+        }
+      }
+
+      beforeEach(async () => {
+        const { ethers, testErc721 } = fixture
+        const [offerer] = await ethers.getSigners()
+        await testErc721.mint(await offerer.getAddress(), nftId)
+      })
+
+      it("leaves the item out and the order stays fillable", async () => {
+        const { ethers, seaport, testErc721 } = fixture
+        const [, , fulfiller] = await ethers.getSigners()
+
+        // 0.5% of 100 floors to 0.
+        const { executeAllActions } = await seaport.createOrder(
+          await listingFor("100", 50),
+        )
+        const order = await executeAllActions()
+
+        expect(order.parameters.consideration).to.have.lengthOf(1)
+        expect(order.parameters.totalOriginalConsiderationItems).to.eq(1)
+
+        const { actions } = await seaport.fulfillOrder({
+          order,
+          accountAddress: await fulfiller.getAddress(),
+        })
+        for (const action of actions) {
+          await (await action.transactionMethods.transact()).wait()
+        }
+
+        expect(await testErc721.ownerOf(nftId)).to.eq(
+          await fulfiller.getAddress(),
+        )
+      })
+
+      it("still adds a fee that survives the rounding", async () => {
+        const { seaport } = fixture
+
+        const { executeAllActions } = await seaport.createOrder(
+          await listingFor("1000", 250),
+        )
+        const order = await executeAllActions()
+
+        expect(
+          order.parameters.consideration.map(item => item.startAmount),
+        ).to.deep.eq(["975", "25"])
+      })
+
+      it("keeps a fee that is only zero at the start of its range", async () => {
+        const { seaport } = fixture
+
+        // Zero at the start, 250 by the end — it still pays over most of the
+        // range, and Seaport only looks at the amount current at fill time.
+        const { executeAllActions } = await seaport.createOrder(
+          await listingFor("10", 250, "10000"),
+        )
+        const order = await executeAllActions()
+
+        expect(order.parameters.consideration).to.have.lengthOf(2)
+        const fee = order.parameters.consideration[1]
+        expect([fee.startAmount, fee.endAmount]).to.deep.eq(["0", "250"])
+      })
+    })
   },
 )


### PR DESCRIPTION
Listing something cheap with a fee produces an order nobody can buy.

`multiplyBasisPoints` floors. Below a certain price the fee lands on 0, and `_formatOrder` appends the consideration item regardless. Seaport rejects zero-amount items with `MissingItemAmount`, so what gets signed is unfillable:

```
price 100,  50 bp  ->  consideration [100, 0]   MissingItemAmount
price 10,  250 bp  ->  consideration [10, 0]    MissingItemAmount
price 1000, 250 bp ->  consideration [975, 25]  fills
```

Creation raises nothing. The seller signs it, publishes it, and finds out when a buyer's fulfillment reverts on an error that says nothing about fees.

Two things make dropping the item the right call rather than rejecting the order:

1. It was never worth anything. `deductFees` floors the same way, so the consideration was not reduced to pay for it — take it out and the totals still add up exactly as the arithmetic intends.
2. Refusing to build the order would block cheap listings outright, which is a worse outcome than a fee of zero being a fee of zero.

One case is deliberately left alone. A fee can floor to zero at the *start* of an ascending range and still pay across the rest of it. Seaport reads the amount current at fill time, and I confirmed against a local chain that an order with a `0 -> 250` fee settles fine. So the item is only dropped when both ends are zero.

Three cases go into `create-order.spec.ts`. The first fails on `main` — the zero item is present and the fulfillment reverts. The other two pass either way on purpose, pinning what should not move: a normal fee still gets added at `975 / 25`, and the `0 -> 250` ascending fee is still there.

Suite 212.
