### PR TITLE
fix: resolve a conduit key regardless of its hex case

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -147,11 +147,15 @@ export class Seaport {
     this.config = {
       ascendingAmountFulfillmentBuffer,
       balanceAndApprovalChecksOnOrderCreation,
-      conduitKeyToConduit: {
-        ...KNOWN_CONDUIT_KEYS_TO_CONDUIT,
-        [NO_CONDUIT]: seaportContractAddress,
-        ...conduitKeyToConduit,
-      },
+      // Keyed lower case so a conduit key still resolves when it arrives in a
+      // different hex case; see _getConduit.
+      conduitKeyToConduit: Object.fromEntries(
+        Object.entries({
+          ...KNOWN_CONDUIT_KEYS_TO_CONDUIT,
+          [NO_CONDUIT]: seaportContractAddress,
+          ...conduitKeyToConduit,
+        }).map(([key, conduit]) => [key.toLowerCase(), conduit]),
+      ),
       seaportVersion,
     }
 
@@ -353,7 +357,7 @@ export class Seaport {
 
     const totalCurrencyAmount = totalItemsAmount(currencies)
 
-    const operator = this.config.conduitKeyToConduit[conduitKey]
+    const operator = this._getConduit(conduitKey)
 
     const orderType = this._getOrderTypeFromOrderOptions({
       allowPartialFills,
@@ -422,6 +426,19 @@ export class Seaport {
     }
 
     return { orderComponents, approvalActions }
+  }
+
+  /**
+   * Resolves the operator to source approvals from for a conduit key.
+   *
+   * A conduit key is a bytes32, so the same key can be written in any hex
+   * case and still be the same value on chain. Looking it up as a raw string
+   * would miss on a key that only differs in case, leaving the operator
+   * undefined and failing later with an error that names neither the conduit
+   * nor the key.
+   */
+  private _getConduit(conduitKey: string): string {
+    return this.config.conduitKeyToConduit[conduitKey.toLowerCase()]
   }
 
   private async _getSigner(
@@ -834,10 +851,9 @@ export class Seaport {
 
     const fulfillerAddress = await fulfiller.getAddress()
 
-    const offererOperator =
-      this.config.conduitKeyToConduit[orderParameters.conduitKey]
+    const offererOperator = this._getConduit(orderParameters.conduitKey)
 
-    const fulfillerOperator = this.config.conduitKeyToConduit[conduitKey]
+    const fulfillerOperator = this._getConduit(conduitKey)
 
     const tipConsiderationItems = tips.map(tip => ({
       ...mapInputItemToOfferItem(tip),
@@ -1003,10 +1019,10 @@ export class Seaport {
 
     const allOffererOperators = fulfillOrderDetails.map(
       ({ order }) =>
-        this.config.conduitKeyToConduit[order.parameters.conduitKey],
+        this._getConduit(order.parameters.conduitKey),
     )
 
-    const fulfillerOperator = this.config.conduitKeyToConduit[conduitKey]
+    const fulfillerOperator = this._getConduit(conduitKey)
 
     const allOfferItems = fulfillOrderDetails.flatMap(
       ({ order }) => order.parameters.offer,

--- a/test/conduit.spec.ts
+++ b/test/conduit.spec.ts
@@ -1,0 +1,183 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import { Seaport } from "../src/seaport"
+import { LocalConduitController__factory } from "../src/typechain-types/index"
+import type {
+  ApprovalAction,
+  CreateOrderInput,
+  OrderWithCounter,
+} from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a user I want a conduit key to resolve whatever hex case it arrives in",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let fulfiller: HardhatEthersSigner
+    let seaport: Seaport
+    let conduitKey: string
+    let conduit: string
+
+    const nftId = "1"
+    const price = parseEther("1")
+
+    const upperCased = (key: string) => `0x${key.slice(2).toUpperCase()}`
+
+    beforeEach(async () => {
+      const { ethers, seaportContract, testErc721 } = fixture
+      ;[offerer, , fulfiller] = await ethers.getSigners()
+
+      // The conduit key has to start with its creator's twenty bytes.
+      conduitKey = `${(await offerer.getAddress()).toLowerCase()}${"00".repeat(11)}01`
+
+      const [, , controllerAddress] = await seaportContract.information()
+      const controller = LocalConduitController__factory.connect(
+        controllerAddress,
+        ethers.provider,
+      )
+
+      await (
+        await controller
+          .connect(offerer)
+          .createConduit(conduitKey, await offerer.getAddress())
+      ).wait()
+      ;[conduit] = await controller.getConduit(conduitKey)
+      await (
+        await controller
+          .connect(offerer)
+          .updateChannel(conduit, await seaportContract.getAddress(), true)
+      ).wait()
+
+      seaport = new Seaport(ethers.provider as never, {
+        overrides: { contractAddress: await seaportContract.getAddress() },
+        conduitKeyToConduit: { [conduitKey]: conduit },
+      })
+
+      await testErc721.mint(await offerer.getAddress(), nftId)
+    })
+
+    const listingWithConduit = async (
+      key: string,
+    ): Promise<CreateOrderInput> => ({
+      startTime: "0",
+      conduitKey: key,
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: await fixture.testErc721.getAddress(),
+          identifier: nftId,
+        },
+      ],
+      consideration: [
+        { amount: price.toString(), recipient: await offerer.getAddress() },
+      ],
+    })
+
+    const createListing = async (key: string): Promise<OrderWithCounter> =>
+      (
+        await seaport.createOrder(
+          await listingWithConduit(key),
+          await offerer.getAddress(),
+        )
+      ).executeAllActions()
+
+    it("approves the conduit when creating with an upper-cased key", async () => {
+      const { actions } = await seaport.createOrder(
+        await listingWithConduit(upperCased(conduitKey)),
+        await offerer.getAddress(),
+      )
+
+      const approval = actions[0] as ApprovalAction
+      expect(approval.type).to.eq("approval")
+      expect(approval.operator).to.eq(conduit)
+    })
+
+    it("fulfills an order carrying an upper-cased key", async () => {
+      const { testErc721 } = fixture
+
+      const order = await createListing(conduitKey)
+      const reCased = {
+        ...order,
+        parameters: {
+          ...order.parameters,
+          conduitKey: upperCased(order.parameters.conduitKey),
+        },
+      }
+
+      const { actions } = await seaport.fulfillOrder({
+        order: reCased,
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      await (
+        await actions[actions.length - 1].transactionMethods.transact()
+      ).wait()
+
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+    })
+
+    it("sources the fulfiller's approvals from an upper-cased key", async () => {
+      const { testErc20, testErc721 } = fixture
+
+      // Price the listing in ERC20 so the fulfiller needs an approval of its
+      // own, which is what the fulfiller side conduit key decides.
+      await testErc20.mint(await fulfiller.getAddress(), price)
+
+      const order = await (
+        await seaport.createOrder(
+          {
+            ...(await listingWithConduit(conduitKey)),
+            consideration: [
+              {
+                amount: price.toString(),
+                token: await testErc20.getAddress(),
+                recipient: await offerer.getAddress(),
+              },
+            ],
+          },
+          await offerer.getAddress(),
+        )
+      ).executeAllActions()
+
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        accountAddress: await fulfiller.getAddress(),
+        conduitKey: upperCased(conduitKey),
+      })
+
+      const approval = actions[0] as ApprovalAction
+      expect(approval.type).to.eq("approval")
+      expect(approval.operator).to.eq(conduit)
+
+      for (const action of actions) {
+        await (await action.transactionMethods.transact()).wait()
+      }
+
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+    })
+
+    it("still resolves a key that matches the configured case", async () => {
+      const { testErc721 } = fixture
+
+      const order = await createListing(conduitKey)
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      await (
+        await actions[actions.length - 1].transactionMethods.transact()
+      ).wait()
+
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+    })
+  },
+)


### PR DESCRIPTION
## Problem

`conduitKeyToConduit` is indexed with the conduit key exactly as it comes in. A conduit key is a `bytes32`, so the same value can be written in any hex case, and a key differing only in case misses the lookup. The operator falls out `undefined`, and what the caller ends up seeing comes from ethers:

```
unsupported addressable value (argument="target", value=null, code=INVALID_ARGUMENT)
```

Nothing there names the conduit, the key, or the config that needed changing.

Five places read that map — the operator approvals are granted to in `_formatOrder`, the offerer and fulfiller operators in `fulfillOrder`, and the same two in `fulfillOrders`. All five are affected, so an order carrying a re-cased key can be neither created nor filled.

This reads as a normalization gap rather than a caller mistake. Everywhere else the SDK compares hex it already lowercases both sides: tokens in `findBalanceAndApproval` and `getSummedTokenAndIdentifierAmounts`, operators in `getApprovalDedupKey`, owners in `balanceOf`, the recipient in `shouldUseBasicFulfill`, currencies in `areAllCurrenciesSame`. Nine of them. The conduit key is the one left keyed on the raw string, and its two sides come from different places — the map is configured by the integrator, the key rides in on order data.

## Fix

Lowercase the map as it is built and lowercase the key on the way in, behind a small private helper so all five sites take the same path. A key already matching the configured case resolves exactly as before.

## Test

There was no conduit coverage at all — the fixture deploys a `ConduitController` but no test ever creates a conduit — so `test/conduit.spec.ts` sets one up off the fixture's own Seaport, opens a channel, and drives creation plus both fulfillment paths.

Three of the four cases stop at the ethers error above without this change. The fourth uses a matching-case key and behaves the same either way, which is what holds the existing path in place.
