### PR TITLE
fix: type executeAllActions as the transaction it actually sends

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { BigNumberish, ContractTransaction } from "ethers"
+import type { BigNumberish, TransactionResponse } from "ethers"
 import type { ItemType, OrderType } from "./constants"
 import type { TestERC20, TestERC721 } from "./typechain-types/index"
 import type { Seaport as SeaportContract } from "./typechain-types/seaport/contracts/Seaport"
@@ -226,7 +226,9 @@ export type OrderUseCase<
       ? OrderWithCounter
       : T extends CreateBulkOrdersAction
         ? OrderWithCounter[]
-        : ContractTransaction
+        : // An exchange use case ends by sending the transaction, so this
+          // resolves to what transact() hands back, receipt and all.
+          TransactionResponse
   >
   /**
    * Performs the approval transactions only, skipping the final action. Use

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -1,9 +1,9 @@
 import {
   type BigNumberish,
-  type ContractTransaction,
   ethers,
   type Overrides,
   type Signer,
+  type TransactionResponse,
 } from "ethers"
 import { BasicOrderRouteType, ItemType, NO_CONDUIT } from "../constants"
 import type {
@@ -323,7 +323,7 @@ export function fulfillBasicOrder(
   return {
     actions,
     executeAllActions: () =>
-      executeAllActions(actions) as Promise<ContractTransaction>,
+      executeAllActions(actions) as Promise<TransactionResponse>,
     executeApprovals: () => executeApprovals(actions),
   }
 }
@@ -531,7 +531,7 @@ export function fulfillStandardOrder(
   return {
     actions,
     executeAllActions: () =>
-      executeAllActions(actions) as Promise<ContractTransaction>,
+      executeAllActions(actions) as Promise<TransactionResponse>,
     executeApprovals: () => executeApprovals(actions),
   }
 }
@@ -835,7 +835,7 @@ export function fulfillAvailableOrders({
   return {
     actions,
     executeAllActions: () =>
-      executeAllActions(actions) as Promise<ContractTransaction>,
+      executeAllActions(actions) as Promise<TransactionResponse>,
     executeApprovals: () => executeApprovals(actions),
   }
 }

--- a/test/execute-all-actions.spec.ts
+++ b/test/execute-all-actions.spec.ts
@@ -1,0 +1,131 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { CreateOrderInput } from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a user I want to wait on the transaction a fulfillment sends",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let fulfiller: HardhatEthersSigner
+
+    const price = parseEther("1")
+
+    beforeEach(async () => {
+      const { ethers } = fixture
+      ;[offerer, , fulfiller] = await ethers.getSigners()
+    })
+
+    const erc721Listing = async (nftId: string): Promise<CreateOrderInput> => ({
+      startTime: "0",
+      offer: [
+        {
+          itemType: ItemType.ERC721,
+          token: await fixture.testErc721.getAddress(),
+          identifier: nftId,
+        },
+      ],
+      consideration: [
+        { amount: price.toString(), recipient: await offerer.getAddress() },
+      ],
+    })
+
+    it("hands back a sent transaction from the basic route", async () => {
+      const { seaport, testErc721 } = fixture
+      const nftId = "1"
+      await testErc721.mint(await offerer.getAddress(), nftId)
+
+      const order = await (
+        await seaport.createOrder(await erc721Listing(nftId))
+      ).executeAllActions()
+
+      const { executeAllActions } = await seaport.fulfillOrder({
+        order,
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const transaction = await executeAllActions()
+      const receipt = await transaction.wait()
+
+      expect(transaction.hash).to.match(/^0x[0-9a-f]{64}$/)
+      expect(receipt?.status).to.eq(1)
+      expect(await testErc721.ownerOf(nftId)).to.eq(
+        await fulfiller.getAddress(),
+      )
+    })
+
+    it("hands back a sent transaction from the advanced route", async () => {
+      const { seaport, testErc1155 } = fixture
+      const nftId = "1"
+      await testErc1155.mint(await offerer.getAddress(), nftId, 10)
+
+      const order = await (
+        await seaport.createOrder({
+          startTime: "0",
+          allowPartialFills: true,
+          offer: [
+            {
+              itemType: ItemType.ERC1155,
+              token: await testErc1155.getAddress(),
+              identifier: nftId,
+              amount: "10",
+            },
+          ],
+          consideration: [
+            {
+              amount: parseEther("10").toString(),
+              recipient: await offerer.getAddress(),
+            },
+          ],
+        })
+      ).executeAllActions()
+
+      const { executeAllActions } = await seaport.fulfillOrder({
+        order,
+        unitsToFill: 4,
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const receipt = await (await executeAllActions()).wait()
+
+      expect(receipt?.status).to.eq(1)
+      expect(
+        await testErc1155.balanceOf(await fulfiller.getAddress(), nftId),
+      ).to.eq(4n)
+    })
+
+    it("hands back a sent transaction from a batch fulfillment", async () => {
+      const { seaport, testErc721 } = fixture
+      const first = "1"
+      const second = "2"
+      await testErc721.mint(await offerer.getAddress(), first)
+      await testErc721.mint(await offerer.getAddress(), second)
+
+      const orders = []
+      for (const nftId of [first, second]) {
+        orders.push(
+          await (
+            await seaport.createOrder(await erc721Listing(nftId))
+          ).executeAllActions(),
+        )
+      }
+
+      const { executeAllActions } = await seaport.fulfillOrders({
+        fulfillOrderDetails: orders.map(order => ({ order })),
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      const receipt = await (await executeAllActions()).wait()
+
+      expect(receipt?.status).to.eq(1)
+      expect(await testErc721.ownerOf(first)).to.eq(
+        await fulfiller.getAddress(),
+      )
+      expect(await testErc721.ownerOf(second)).to.eq(
+        await fulfiller.getAddress(),
+      )
+    })
+  },
+)


### PR DESCRIPTION
Writing the obvious thing after a fulfillment does not compile:

```ts
const transaction = await useCase.executeAllActions()
await transaction.wait()
//                 ^ Property 'wait' does not exist on type 'ContractTransaction'
```

It runs perfectly well. Only the annotation is wrong.

On an exchange use case `executeAllActions` returns `finalAction.transactionMethods.transact()`, and `transact()` is itself declared as `Promise<TransactionResponse>`. But `OrderUseCase` names `ContractTransaction` for that branch, and the three fulfill helpers cast to it on the way out. In ethers v6 those are not the same thing at all — `ContractTransaction` is a prepared request, `TransactionResponse` is a transaction that has already gone out. `hash`, `wait()` and `confirmations()` live on the response and simply do not exist on the request.

Logging the value at runtime settles which one it is:

```
constructor       TransactionResponse
has .wait()       true
has .hash         true
```

So the practical cost is that anyone who wants a receipt has to cast through `any` to reach it, on code that was already correct.

The change points that branch and the three casts at `TransactionResponse`. Nothing moves at runtime — `transact()` was always returning it.

For coverage there is a new `execute-all-actions.spec.ts` that awaits and then `wait()`s the result on all three routes the casts sit behind: basic, advanced, and the batch path through `fulfillOrders`, checking the receipt status and that the items really moved. What makes it a regression test is that it is the type checker, not mocha, that catches a relapse — drop the change and `npm run check-types` reports four errors on those lines while the tests themselves still go green, which is the whole shape of this bug.

