### PR TITLE
fix: export the symbols the docs tell people to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Many of the main core flows return _use cases_. What this means is that if you w
 #### Listing an ERC-721 for 10 ETH and fulfilling it
 
 ```js
+import { ItemType } from "@opensea/seaport-js";
+
 const offerer = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
 const fulfiller = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8";
 const { executeAllActions } = await seaport.createOrder(
@@ -126,13 +128,15 @@ const transaction = await executeAllFulfillActions();
 #### Making an offer for an ERC-721 for 10 WETH and fulfilling it
 
 ```js
+import { ItemType } from "@opensea/seaport-js";
+
 const offerer = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
 const fulfiller = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8";
 const { executeAllActions } = await seaport.createOrder(
   {
     offer: [
       {
-        amount: parseEther("10").toString(),
+        amount: ethers.parseEther("10").toString(),
         // WETH
         token: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { ItemType } from "./constants"
 import { Seaport } from "./seaport"
+import { getMaximumSizeForOrder } from "./utils/item"
 
-export { Seaport }
+export { getMaximumSizeForOrder, ItemType, Seaport }

--- a/test/public-exports.spec.ts
+++ b/test/public-exports.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai"
+import * as seaportJs from "../src/index"
+
+// The entry point is all a consumer can reach without a deep import, so
+// anything the docs hand them has to be reachable from here.
+describe("public exports", () => {
+  it("exports the client", () => {
+    expect(seaportJs).to.have.property("Seaport")
+  })
+
+  it("exports ItemType, which the README's order examples are written with", () => {
+    expect(seaportJs).to.have.property("ItemType")
+    expect(seaportJs.ItemType.ERC721).to.eq(2)
+  })
+
+  it("exports getMaximumSizeForOrder, which fulfillOrder's docs point at", () => {
+    expect(seaportJs).to.have.property("getMaximumSizeForOrder")
+    expect(seaportJs.getMaximumSizeForOrder).to.be.a("function")
+  })
+})


### PR DESCRIPTION
## Problem

The entry point exports `Seaport` and nothing else, so that is the whole surface a consumer gets without a deep import:

```
> require("@opensea/seaport-js")
[ 'Seaport' ]
```

Both order examples in the README are written with `ItemType.ERC721`, and neither imports it — because there is nowhere to import it from. Copy either example and `ItemType` is undefined.

`fulfillOrder`'s doc comment has the same gap:

> Units to fill are denominated by the max possible size of the order, which is the greatest common denominator (GCD). We expose a helper to get this: `getMaximumSizeForOrder`

That helper is not exported either.

## Fix

Export the two the documentation already promises, and add the import line the README examples were missing. Adding to the entry point breaks nothing — `Seaport` resolves exactly as before.

While in those two code blocks: the second reached for a bare `parseEther` where the first uses `ethers.parseEther`, so it now matches its neighbour.

I stopped there on purpose. The rest of the constants and the input types are still deep-import only, and widening the public surface past what the docs already claim felt like a call to make deliberately rather than as a side effect of this. Happy to extend it if you'd rather the whole surface came out.

## Test

`test/public-exports.spec.ts` asserts the entry point carries the client, `ItemType`, and `getMaximumSizeForOrder`. Two of the three go red against the current `src/index.ts`.

Building and requiring `lib/index.js` afterwards gives `ItemType, Seaport, getMaximumSizeForOrder`.
