### PR TITLE
fix: check the fulfiller can cover a whole batch, not just each order

### DIFF
--- a/src/utils/balanceAndApprovalCheck.ts
+++ b/src/utils/balanceAndApprovalCheck.ts
@@ -332,6 +332,58 @@ export const validateBasicFulfillBalancesAndApprovals = ({
  *
  * @returns the list of insufficient owner and proxy approvals
  */
+/**
+ * Check the fulfiller can cover a whole batch, not just each order in it.
+ *
+ * `fulfillOrders` validates every order against the same un-decremented
+ * balances, so a fulfiller who can afford each order individually but not all
+ * of them together was handed a transaction that cannot succeed, with no error.
+ *
+ * Currency the batch pays the fulfiller is credited, because it is load-bearing:
+ * accepting a bid means its ERC20 fee items sit in the consideration the
+ * fulfiller owes while being funded by the bid's own ERC20 offer. The per-order
+ * check handles that by crediting each order's offer before checking its
+ * consideration, and this has to match, or every offer-fulfillment batch would
+ * be rejected. Note the credit is batch-wide while the per-order check is
+ * per-order, so this is the looser of the two and cannot reject anything the
+ * per-order check accepts for a reason other than the batch total.
+ *
+ * Scoped to ERC20 deliberately. Native balances cannot be checked without
+ * modelling gas, and an over-strict check here would block a working batch,
+ * which is worse than the silence it replaces. A token with no entry is skipped
+ * for the same reason.
+ */
+export const validateCumulativeFulfillerBalances = ({
+  requiredAmounts,
+  receivedAmounts,
+  fulfillerBalancesAndApprovals,
+}: {
+  requiredAmounts: Record<string, Record<string, bigint>>
+  receivedAmounts: Record<string, Record<string, bigint>>
+  fulfillerBalancesAndApprovals: BalancesAndApprovals
+}) => {
+  for (const [token, identifierToAmount] of Object.entries(requiredAmounts)) {
+    for (const [identifierOrCriteria, required] of Object.entries(
+      identifierToAmount,
+    )) {
+      const balanceAndApproval = fulfillerBalancesAndApprovals.find(
+        entry =>
+          entry.token.toLowerCase() === token.toLowerCase() &&
+          entry.identifierOrCriteria === identifierOrCriteria,
+      )
+      if (!balanceAndApproval || !isErc20Item(balanceAndApproval.itemType)) {
+        continue
+      }
+      const received = receivedAmounts[token]?.[identifierOrCriteria] ?? 0n
+      if (balanceAndApproval.balance + received < required) {
+        throw new Error(
+          "The fulfiller does not have the balances needed to fulfill.",
+        )
+      }
+    }
+  }
+}
+
 export const validateStandardFulfillBalancesAndApprovals = ({
   offer,
   consideration,

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -28,6 +28,7 @@ import {
   type BalancesAndApprovals,
   type InsufficientApprovals,
   validateBasicFulfillBalancesAndApprovals,
+  validateCumulativeFulfillerBalances,
   validateStandardFulfillBalancesAndApprovals,
 } from "./balanceAndApprovalCheck"
 import { generateCriteriaResolvers, getItemToCriteriaMap } from "./criteria"
@@ -677,6 +678,10 @@ export function fulfillAvailableOrders({
   // an ERC20 approval is one allowance shared by every order in the batch, so
   // the amount to approve is this total rather than any single order's share.
   const cumulativeFulfillerAmounts: Record<string, Record<string, bigint>> = {}
+  // What the batch pays the fulfiller, which funds part of what it owes: a
+  // bid's ERC20 fee items are consideration the fulfiller owes but are paid out
+  // of the bid's own ERC20 offer.
+  const cumulativeReceivedAmounts: Record<string, Record<string, bigint>> = {}
   const criteriaOffersAndConsiderations = sanitizedOrdersMetadata
     .flatMap(orderMetadata => [
       orderMetadata.order.parameters.offer,
@@ -744,6 +749,23 @@ export function fulfillAvailableOrders({
         }
       }
 
+      const summedOffer = getSummedTokenAndIdentifierAmounts({
+        items: order.parameters.offer,
+        criterias: offerCriteria,
+        timeBasedItemParams: {
+          ...timeBasedItemParams,
+          isConsiderationItem: false,
+        },
+      })
+
+      for (const [token, identifierToAmount] of Object.entries(summedOffer)) {
+        for (const [identifier, amount] of Object.entries(identifierToAmount)) {
+          cumulativeReceivedAmounts[token] ??= {}
+          cumulativeReceivedAmounts[token][identifier] =
+            (cumulativeReceivedAmounts[token][identifier] ?? 0n) + amount
+        }
+      }
+
       const insufficientApprovals = validateStandardFulfillBalancesAndApprovals(
         {
           offer: order.parameters.offer,
@@ -780,6 +802,12 @@ export function fulfillAvailableOrders({
   )
 
   overrides = { ...overrides, value: totalNativeAmount }
+
+  validateCumulativeFulfillerBalances({
+    requiredAmounts: cumulativeFulfillerAmounts,
+    receivedAmounts: cumulativeReceivedAmounts,
+    fulfillerBalancesAndApprovals,
+  })
 
   // An approval is deduped to one action per token and operator, and with
   // exactApproval that action approves `requiredApprovedAmount`. Left as the

--- a/test/fulfill-orders.spec.ts
+++ b/test/fulfill-orders.spec.ts
@@ -1316,6 +1316,122 @@ describeWithFixture(
         )
       })
     })
+    describe("cumulative fulfiller balance", () => {
+      it("rejects a batch the fulfiller cannot cover, even when each order alone is affordable", async () => {
+        const { seaport, testErc721, testErc20 } = fixture
+
+        await testErc721.mint(await offerer.getAddress(), nftId)
+        await testErc721.mint(await secondOfferer.getAddress(), nftId2)
+        // Enough for either listing on its own, not for both together.
+        await testErc20.mint(
+          await fulfiller.getAddress(),
+          parseEther("25").toString(),
+        )
+
+        const listing = async (
+          seller: HardhatEthersSigner,
+          identifier: string,
+          price: string,
+        ) =>
+          (
+            await seaport.createOrder(
+              {
+                offer: [
+                  {
+                    itemType: ItemType.ERC721,
+                    token: await testErc721.getAddress(),
+                    identifier,
+                  },
+                ],
+                consideration: [
+                  {
+                    amount: parseEther(price).toString(),
+                    token: await testErc20.getAddress(),
+                    recipient: await seller.getAddress(),
+                  },
+                ],
+              },
+              await seller.getAddress(),
+            )
+          ).executeAllActions()
+
+        const firstOrder = await listing(offerer, nftId, "10")
+        const secondOrder = await listing(secondOfferer, nftId2, "20")
+
+        await expect(
+          seaport.fulfillOrders({
+            fulfillOrderDetails: [
+              { order: firstOrder },
+              { order: secondOrder },
+            ],
+            accountAddress: await fulfiller.getAddress(),
+          }),
+        ).to.be.rejectedWith(
+          "The fulfiller does not have the balances needed to fulfill.",
+        )
+      })
+
+      it("allows a batch the fulfiller can cover in total", async () => {
+        const { seaport, testErc721, testErc20 } = fixture
+
+        await testErc721.mint(await offerer.getAddress(), nftId)
+        await testErc721.mint(await secondOfferer.getAddress(), nftId2)
+        // Exactly enough for both listings together.
+        await testErc20.mint(
+          await fulfiller.getAddress(),
+          parseEther("30").toString(),
+        )
+
+        const listing = async (
+          seller: HardhatEthersSigner,
+          identifier: string,
+          price: string,
+        ) =>
+          (
+            await seaport.createOrder(
+              {
+                offer: [
+                  {
+                    itemType: ItemType.ERC721,
+                    token: await testErc721.getAddress(),
+                    identifier,
+                  },
+                ],
+                consideration: [
+                  {
+                    amount: parseEther(price).toString(),
+                    token: await testErc20.getAddress(),
+                    recipient: await seller.getAddress(),
+                  },
+                ],
+              },
+              await seller.getAddress(),
+            )
+          ).executeAllActions()
+
+        const firstOrder = await listing(offerer, nftId, "10")
+        const secondOrder = await listing(secondOfferer, nftId2, "20")
+
+        // The cumulative check must not reject a batch that balances exactly.
+        const { actions } = await seaport.fulfillOrders({
+          fulfillOrderDetails: [{ order: firstOrder }, { order: secondOrder }],
+          accountAddress: await fulfiller.getAddress(),
+        })
+
+        for (const action of actions.filter(a => a.type === "approval")) {
+          await action.transactionMethods.transact()
+        }
+        await actions[actions.length - 1].transactionMethods.transact()
+
+        expect(await testErc721.ownerOf(nftId)).to.equal(
+          await fulfiller.getAddress(),
+        )
+        expect(await testErc721.ownerOf(nftId2)).to.equal(
+          await fulfiller.getAddress(),
+        )
+      })
+    })
+
     // TODO
     describe("Special use cases", () => {
       it("Can fulfill dutch auction orders", () => {})


### PR DESCRIPTION
`fulfillOrders` validated every order against the same un-decremented balances, so a fulfiller who could afford each order individually but not all of them together got no error at all. The SDK returned an exchange action and handed back a transaction that cannot succeed.

Measured: a fulfiller holding 25 against two listings priced 10 and 20 in the same ERC20. `fulfillOrders` returned `approval, exchange` rather than throwing `The fulfiller does not have the balances needed to fulfill.`

This is the sibling of #975. There the native total accumulated while the approval amount did not; here the native total accumulates while the balance requirement does not.

## The part I got wrong first, since it shaped the design

My first version dropped the credit for currency the batch pays the fulfiller, on the reasoning that the per-order check already rejects any order the fulfiller cannot afford from their raw balance, making such a credit unreachable.

That was wrong, and the existing suite caught it: four tests broke, all offer fulfillments ("ERC20 <=> ERC721", "ERC20 <=> ERC1155", the criteria-based pair, and the contract-wallet order). Accepting a bid puts its ERC20 fee items in the consideration the fulfiller owes while they are funded by the bid's own ERC20 offer, and the per-order check handles that by crediting each order's offer before checking its consideration. Without the credit, every offer-fulfillment batch would be rejected.

So the credit is load-bearing rather than defensive, and the helper now records why, so nobody removes it for the reason I nearly did.

## Scope, deliberately narrow

ERC20 only. Native balances cannot be checked without modelling gas, and a token with no lookup entry is skipped rather than treated as zero. Both are the fail-open direction on purpose: an over-strict check here blocks a working batch, which is worse than the silence it replaces.

The credit is batch-wide while the per-order check is per-order, so this check is the looser of the two and cannot reject anything the per-order check accepts except on the batch total, which is the case it exists for.

## Verification

`npm run build`, `npm run lint` (tsc and Biome), and `npm test` all clean at 212 passing.

Tripwire: disabling the check, with the tests left in place, fails on the assertion it is named for:

```
AssertionError: expected promise to be rejected with an error including
'The fulfiller does not have the balan…' but it was fulfilled with { …(3) }
```

That fulfilled value is the doomed transaction being handed back. The companion test, that a batch the fulfiller can cover in total still goes through and both NFTs transfer, passes on both sides of the tripwire, so the check is not over-firing.

## Behavior change

Order sets that today build a transaction destined to revert will now throw client-side instead. That is the intent, and it is why this was raised for a decision rather than bundled into #975.

## Still outstanding

`createBulkOrders` has the same root cause on the offerer side: per-input approvals are merged by dedup key, keeping the first, so two ERC20 offers approve only the first input's amount. A clean fix needs `_formatOrder` to return its insufficient approvals so the check can be cumulative, which is order-creation surface rather than the fulfill path. A sum-on-dedup half-fix would hit the same partial-allowance trap described in #975.
