### PR TITLE
fix: do not credit a forwarded offer to the batch balance check

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -744,6 +744,15 @@ export function fulfillAvailableOrders({
   // What the batch pays the fulfiller, which funds part of what it owes: a
   // bid's ERC20 fee items are consideration the fulfiller owes but are paid out
   // of the bid's own ERC20 offer.
+  //
+  // Only when the offer actually reaches the fulfiller. `recipientAddress`
+  // forwards it elsewhere, and then every consideration item has to come out of
+  // what the fulfiller already holds -- the same reasoning the per-order check
+  // applies via `offerItemsGoToFulfiller`.
+  const offerItemsGoToFulfiller = offerItemsLandWithFulfiller(
+    recipientAddress,
+    fulfillerAddress,
+  )
   const cumulativeReceivedAmounts: Record<string, Record<string, bigint>> = {}
   const criteriaOffersAndConsiderations = sanitizedOrdersMetadata
     .flatMap(orderMetadata => [
@@ -812,20 +821,24 @@ export function fulfillAvailableOrders({
         }
       }
 
-      const summedOffer = getSummedTokenAndIdentifierAmounts({
-        items: order.parameters.offer,
-        criterias: offerCriteria,
-        timeBasedItemParams: {
-          ...timeBasedItemParams,
-          isConsiderationItem: false,
-        },
-      })
+      if (offerItemsGoToFulfiller) {
+        const summedOffer = getSummedTokenAndIdentifierAmounts({
+          items: order.parameters.offer,
+          criterias: offerCriteria,
+          timeBasedItemParams: {
+            ...timeBasedItemParams,
+            isConsiderationItem: false,
+          },
+        })
 
-      for (const [token, identifierToAmount] of Object.entries(summedOffer)) {
-        for (const [identifier, amount] of Object.entries(identifierToAmount)) {
-          cumulativeReceivedAmounts[token] ??= {}
-          cumulativeReceivedAmounts[token][identifier] =
-            (cumulativeReceivedAmounts[token][identifier] ?? 0n) + amount
+        for (const [token, identifierToAmount] of Object.entries(summedOffer)) {
+          for (const [identifier, amount] of Object.entries(
+            identifierToAmount,
+          )) {
+            cumulativeReceivedAmounts[token] ??= {}
+            cumulativeReceivedAmounts[token][identifier] =
+              (cumulativeReceivedAmounts[token][identifier] ?? 0n) + amount
+          }
         }
       }
 
@@ -840,10 +853,7 @@ export function fulfillAvailableOrders({
           timeBasedItemParams,
           offererOperator,
           fulfillerOperator,
-          offerItemsGoToFulfiller: offerItemsLandWithFulfiller(
-            recipientAddress,
-            fulfillerAddress,
-          ),
+          offerItemsGoToFulfiller,
         },
       )
 

--- a/test/fulfill-orders-forwarded-offer.spec.ts
+++ b/test/fulfill-orders-forwarded-offer.spec.ts
@@ -1,0 +1,105 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { CreateOrderInput, OrderWithCounter } from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+describeWithFixture(
+  "As a user accepting several bids I want the batch check to know where the proceeds go",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let zone: HardhatEthersSigner
+    let fulfiller: HardhatEthersSigner
+    let recipient: HardhatEthersSigner
+    let firstBid: OrderWithCounter
+    let secondBid: OrderWithCounter
+
+    const bidAmount = parseEther("10")
+    // A 250bp fee on each bid is 0.25, so the batch costs the fulfiller 0.5.
+    // They hold 0.3: enough for either bid alone, not for both.
+    const fulfillerBalance = parseEther("0.3")
+
+    beforeEach(async () => {
+      const { ethers, seaport, testErc20, testErc721 } = fixture
+      ;[offerer, zone, fulfiller, recipient] = await ethers.getSigners()
+
+      await testErc721.mint(await fulfiller.getAddress(), "301")
+      await testErc721.mint(await fulfiller.getAddress(), "302")
+      await testErc20.mint(await offerer.getAddress(), bidAmount * 2n)
+      await testErc20.mint(await fulfiller.getAddress(), fulfillerBalance)
+
+      const buildBid = async (nftId: string) => {
+        const input: CreateOrderInput = {
+          startTime: "0",
+          offer: [
+            {
+              token: await testErc20.getAddress(),
+              amount: bidAmount.toString(),
+            },
+          ],
+          consideration: [
+            {
+              itemType: ItemType.ERC721,
+              token: await testErc721.getAddress(),
+              identifier: nftId,
+              recipient: await offerer.getAddress(),
+            },
+          ],
+          fees: [{ recipient: await zone.getAddress(), basisPoints: 250 }],
+        }
+        return (
+          await seaport.createOrder(input, await offerer.getAddress())
+        ).executeAllActions()
+      }
+
+      firstBid = await buildBid("301")
+      secondBid = await buildBid("302")
+    })
+
+    it("reports the shortfall when the batch's proceeds go elsewhere", async () => {
+      const { seaport } = fixture
+
+      // The offer never reaches the fulfiller, so both fees come out of the
+      // 0.3 they hold. Crediting the batch's own offer here would clear a
+      // fulfillment that reverts on transfer.
+      await expect(
+        seaport.fulfillOrders({
+          fulfillOrderDetails: [{ order: firstBid }, { order: secondBid }],
+          accountAddress: await fulfiller.getAddress(),
+          recipientAddress: await recipient.getAddress(),
+        }),
+      ).to.be.rejectedWith("The fulfiller does not have the balances needed")
+    })
+
+    it("still lets the batch fund its own fees when the proceeds are kept", async () => {
+      const { seaport, testErc20 } = fixture
+
+      const { actions } = await seaport.fulfillOrders({
+        fulfillOrderDetails: [{ order: firstBid }, { order: secondBid }],
+        accountAddress: await fulfiller.getAddress(),
+      })
+
+      for (const action of actions) {
+        await (await action.transactionMethods.transact()).wait()
+      }
+
+      // 0.3 held, 20 received, 0.5 paid out in fees.
+      expect(await testErc20.balanceOf(await fulfiller.getAddress())).to.eq(
+        parseEther("19.8"),
+      )
+    })
+
+    it("still accepts a single order the fulfiller can cover alone", async () => {
+      const { seaport } = fixture
+
+      const { actions } = await seaport.fulfillOrder({
+        order: firstBid,
+        accountAddress: await fulfiller.getAddress(),
+        recipientAddress: await recipient.getAddress(),
+      })
+
+      expect(actions.length).to.be.greaterThan(0)
+    })
+  },
+)


### PR DESCRIPTION
Found while verifying `main` after #984 and #985 merged, 18 seconds apart. Both are correct on their own; this is the gap between them.

## What is wrong

#978 (in #985) stopped `validateStandardFulfillBalancesAndApprovals` crediting the fulfiller with offer items that `recipientAddress` forwards to someone else. When the offer lands elsewhere, every consideration item has to come out of what the fulfiller already holds.

#984 added `validateCumulativeFulfillerBalances` so a batch is checked against its total rather than order by order. It builds `cumulativeReceivedAmounts` from each order's offer unconditionally, with no knowledge of `recipientAddress`, so the batch path still credits an offer the fulfiller never receives.

The two branches of the same function now disagree about whether a forwarded offer funds the fulfiller.

## It is reachable

A fulfiller holding 0.3 ERC20 accepts two bids of 10 ERC20, each carrying a 250 bp fee. Each fee is 0.25, so the batch costs them 0.5.

| | |
|---|---|
| Either bid alone, forwarded | 0.25 owed against 0.3 held, accepted, correctly |
| Both bids, forwarded | 0.5 owed against 0.3 held, accepted, reverts on transfer |

The per-order check passes each order because 0.25 fits inside 0.3, so it never fires. The batch check then clears 0.5 against a credit of 20 ERC20 that goes to the recipient rather than the fulfiller. Measured on `main` at 4fdd176 before this change:

```
PROBE single order (0.25 owed, 0.3 held): accepted, as expected
PROBE batch (0.5 owed, 0.3 held, forwarded): rejected=false
```

This is not a regression from #985. Before #978 the single-order path had the same hole, and #984's batch credit is right for the ordinary case where proceeds are kept. Nothing on `main` is broken today: lint, tests and coverage are all green, and this is a fulfillment the SDK accepts that the chain will reject.

## Change

Hoist `offerItemsLandWithFulfiller(recipientAddress, fulfillerAddress)` to the top of `fulfillAvailableOrders` and accumulate `cumulativeReceivedAmounts` only when it holds. The per-order call site reuses the same value rather than recomputing it, so the two checks cannot drift apart again.

The credit stays batch-wide when the proceeds are kept, so #984's reasoning about offer-fulfillment batches is untouched.

## Tests

`test/fulfill-orders-forwarded-offer.spec.ts`, three cases. Reverting only `src/utils/fulfill.ts` fails one of them, on its own assertion:

```
1) reports the shortfall when the batch's proceeds go elsewhere:
   AssertionError: expected promise to be rejected with an error including
   'The fulfiller does not have the balan…' but it was fulfilled with
   { actions: [ { …(6) }, …(2) ], …(2) }
```

The other two are controls and pass either way: a kept-proceeds batch still funds its own fees and settles at 19.8, and a single forwarded order the fulfiller can cover alone is still accepted.

`npm run lint` clean, `npm test` 242 passing 0 failing, up from 239 on `main`.
