### PR TITLE
docs: add a security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Getting Started](#getting-started)
   - [Use Cases](#use-cases)
 - [Contributing](#contributing)
+- [Security](#security)
 
 ## Synopsis
 
@@ -167,6 +168,10 @@ const transaction = await executeAllFulfillActions();
 ## Contributing
 
 See [the contributing guide](./.github/CONTRIBUTING.md) for detailed instructions on how to get started with this project.
+
+## Security
+
+Found a vulnerability? Report it through OpenSea's Bugcrowd program at https://bugcrowd.com/engagements/opensea rather than opening a public issue. See [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report it through OpenSea's Bugcrowd program:
+
+**https://bugcrowd.com/engagements/opensea**
+
+That is the channel OpenSea's security team monitors, and it is where a report gets triaged and tracked. Please do not open a public GitHub issue, discussion, or pull request describing a vulnerability, and please hold off on public disclosure until the program has responded.
+
+The Bugcrowd brief is the authority on what is in scope, what is excluded, how severity is assessed, and how rewards work. This file deliberately does not restate any of that, because a second copy would drift out of date and contradict the brief. Read the brief before you start.
+
+Response and disclosure timelines are set by the program, not by this repository.
+
+## About this repository
+
+`@opensea/seaport-js` is a TypeScript library for the [Seaport](https://github.com/ProjectOpenSea/seaport) marketplace protocol. It builds order structs, produces the EIP-712 payload a wallet signs, runs balance and approval checks, and assembles the fulfillment calldata.
+
+It moves assets. Code here decides what a user is asked to sign and what a transaction ends up doing, so a bug in order construction, in the approval or balance checks, in fulfillment or criteria resolution, or in the recipient and amount arithmetic can cost a user NFTs or tokens even though the library holds no funds itself. Reports in that area are worth filing carefully, with the order parameters and the resulting calldata included.
+
+Seaport the protocol lives in a [separate repository](https://github.com/ProjectOpenSea/seaport). A bug in the contracts is not a bug in this library. Report it through the same Bugcrowd program and say which repository it affects.
+
+## Please do not
+
+- Test against production. Do not run exploit attempts against opensea.io, api.opensea.io, or any other OpenSea-operated service. Reproduce against a local fork, a testnet, or your own deployment.
+- Run automated scanners, fuzzers, or crawlers against opensea.io or the OpenSea API. That traffic is indistinguishable from an attack, it gets blocked, and raw scanner output on its own is not a report.
+- Touch accounts, wallets, or data that are not yours. Use your own.
+- Attempt denial of service, spam, or social engineering against OpenSea staff, users, or infrastructure.
+
+We cannot accept a finding that required breaking one of these to produce, however real the underlying bug is.


### PR DESCRIPTION
## Motivation

This repository has no `SECURITY.md`, and neither does any other public ProjectOpenSea repo. A researcher who finds something here has nothing in the repo to follow, so the report lands as a public issue. That already happened in a sibling repo: [ProjectOpenSea/tool-sdk#14](https://github.com/ProjectOpenSea/tool-sdk/issues/14) opens by saying it was filed publicly because private vulnerability reporting is off and there is no `SECURITY.md`. That reporter also reasoned about the Bugcrowd brief and its exclusions, so the program is not the missing piece. The signposting is.

This matters more here than in most of the org's repos, because seaport-js moves assets. It builds order structs, produces the EIP-712 payload a wallet signs, runs the balance and approval checks, and assembles the fulfillment calldata. A bug in any of that decides what a user is asked to sign and what their transaction does.

## Solution

`SECURITY.md` at the repo root, plus a Security section in the README and a matching table-of-contents entry. Both point to OpenSea's Bugcrowd program at https://bugcrowd.com/engagements/opensea.

The file links the Bugcrowd brief as the authority on scope, exclusions, severity, and rewards rather than restating any of it, so this copy cannot drift out of step with the program. What it does carry:

- Where to report, stated first, with no competing channel.
- What this library is and where its risk sits, including a note that Seaport the protocol lives in another repository.
- A "please do not" list: no exploit attempts against opensea.io, api.opensea.io, or any other OpenSea-operated service, no automated scanners or fuzzers pointed at production, no touching accounts or data that are not yours, no denial of service or social engineering.

Response and disclosure timelines are left to the program rather than promised here.

## Manual follow-up for a human

1. Confirm https://bugcrowd.com/engagements/opensea is the right destination for this repo, and that the brief's scope covers marketplace client library code and not only the opensea.io web surface. The whole file hangs off that link, so it is worth one look. If the brief scopes this code out, the link sends researchers somewhere that will turn them away.
2. Optionally enable GitHub private vulnerability reporting (Settings, Code security) as a secondary path for repo-specific issues. It is off today. The file does not mention it, deliberately, since Bugcrowd is the channel that gets triaged. Enabling it does add a "Report a vulnerability" button to the Security tab, which is another place a researcher looks before giving up and filing publicly.

## Verification

Documentation only, no source changed. Biome here is configured for `**/*.ts`, `**/*.js`, and `**/*.json`, so markdown is outside format and lint.

Run in a fresh worktree, exit codes captured rather than eyeballed:

| Check | Result |
|---|---|
| `npm ci --ignore-scripts` | 0 |
| `npm run build` | 0 |
| `npm run check-types` | 0 |
| `npm run format:check` | 0 |
| `npx biome check .` | 0 |
| `npm run lint` | 0 |
