### PR TITLE
test: derive the public-export check from the docs instead of a fixed list

### DIFF
--- a/test/public-exports.spec.ts
+++ b/test/public-exports.spec.ts
@@ -1,20 +1,232 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import { expect } from "chai"
 import * as seaportJs from "../src/index"
 
-// The entry point is all a consumer can reach without a deep import, so
-// anything the docs hand them has to be reachable from here.
+/**
+ * The entry point is all a consumer can reach without a deep import, so
+ * anything the docs hand them has to be reachable from here. seaport-js#983
+ * shipped a README whose two order examples were written with `ItemType` and a
+ * `fulfillOrder` doc comment that pointed readers at `getMaximumSizeForOrder`,
+ * while `src/index.ts` exported only `Seaport`. Both examples failed at import
+ * for anyone who copied them, and a member of the public reported it.
+ *
+ * These checks read the docs instead of restating them, so they keep working
+ * as the docs change.
+ *
+ * What is covered:
+ *
+ * - Every named value import from `@opensea/seaport-js` written in a fenced
+ *   code block in README.md is reachable from `src/index.ts`.
+ * - Every identifier named in an "expose" sentence inside a JSDoc block in
+ *   `src/`, where that identifier is also a top-level exported declaration
+ *   somewhere in `src/`, is reachable from `src/index.ts`.
+ *
+ * What is NOT covered:
+ *
+ * - Type-only imports (`import type { … }`, or a `type X` specifier). They
+ *   vanish at runtime, so a module namespace cannot be asked about them.
+ *   `npm run lint` runs `tsc`, which does resolve those.
+ * - Deep imports (`@opensea/seaport-js/lib/…`), which bypass the entry point
+ *   by design.
+ * - Member access on an imported symbol. A README that writes
+ *   `ItemType.NOT_A_REAL_MEMBER` still passes, because only the import is read.
+ * - Prose outside a fenced code block, and any doc-comment promise phrased
+ *   without the word "expose".
+ * - Docs outside README.md and `src/`.
+ */
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const SRC = join(ROOT, "src")
+
+/** Generated output that lives under src/ but is not hand-written source. */
+const GENERATED_DIRS = new Set(["artifacts", "contracts", "typechain-types"])
+
+const PACKAGE_NAME = (
+  JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {
+    name: string
+  }
+).name
+
+const publicExports = new Set(Object.keys(seaportJs))
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return GENERATED_DIRS.has(entry.name) ? [] : sourceFiles(full)
+    }
+    return entry.isFile() && entry.name.endsWith(".ts") ? [full] : []
+  })
+}
+
+const SOURCE_FILES = sourceFiles(SRC)
+
+/**
+ * Named value imports of the package written in README code fences, e.g.
+ * `import { ItemType } from "@opensea/seaport-js"`.
+ *
+ * A whole `import type { … }` statement and an individual `type X` specifier
+ * are both dropped: neither exists at runtime.
+ */
+function readmeImportedSymbols(): { symbol: string; statement: string }[] {
+  const readme = readFileSync(join(ROOT, "README.md"), "utf8")
+  const fence = /```[a-zA-Z]*\n([\s\S]*?)```/g
+  const importStatement = new RegExp(
+    `import\\s+(type\\s+)?\\{([^}]*)\\}\\s*from\\s*["']${escapeForRegExp(
+      PACKAGE_NAME,
+    )}["']`,
+    "g",
+  )
+
+  const found: { symbol: string; statement: string }[] = []
+  for (const [, block] of readme.matchAll(fence)) {
+    for (const [statement, typeOnly, specifiers] of block.matchAll(
+      importStatement,
+    )) {
+      if (typeOnly) {
+        continue
+      }
+      for (const specifier of specifiers.split(",")) {
+        const name = specifier
+          .trim()
+          .split(/\s+as\s+/)[0]
+          .trim()
+        if (name && !name.startsWith("type ")) {
+          found.push({ symbol: name, statement: statement.trim() })
+        }
+      }
+    }
+  }
+  return found
+}
+
+/** Names of top-level exported declarations anywhere under `src/`. */
+function exportedDeclarations(): Set<string> {
+  const declaration =
+    /^export\s+(?:declare\s+)?(?:abstract\s+)?(?:async\s+)?(?:const|let|var|function|class|type|interface|enum)\s+([A-Za-z_$][\w$]*)/gm
+  const reExportList = /^export\s*\{([^}]*)\}/gm
+
+  const names = new Set<string>()
+  for (const file of SOURCE_FILES) {
+    const text = readFileSync(file, "utf8")
+    for (const [, name] of text.matchAll(declaration)) {
+      names.add(name)
+    }
+    for (const [, specifiers] of text.matchAll(reExportList)) {
+      for (const specifier of specifiers.split(",")) {
+        const parts = specifier.trim().split(/\s+as\s+/)
+        const name = (parts[1] ?? parts[0] ?? "").trim().replace(/^type\s+/, "")
+        if (name) {
+          names.add(name)
+        }
+      }
+    }
+  }
+  return names
+}
+
+/**
+ * Identifiers a JSDoc block promises are exposed.
+ *
+ * The window read for each promise starts at the word "expose" and stops at
+ * the first sentence break, the first JSDoc tag, or 200 characters, whichever
+ * comes first. Only identifiers that are also top-level exported declarations
+ * in `src/` count, which is what keeps ordinary English out of the result.
+ */
+function docCommentPromises(): {
+  symbol: string
+  file: string
+  sentence: string
+}[] {
+  const exported = exportedDeclarations()
+  const docBlock = /\/\*\*[\s\S]*?\*\//g
+  const promise = /\bexpose[sd]?\b/gi
+
+  const found: { symbol: string; file: string; sentence: string }[] = []
+  for (const file of SOURCE_FILES) {
+    for (const [block] of readFileSync(file, "utf8").matchAll(docBlock)) {
+      const prose = block
+        .replace(/^\s*\/\*\*|\*\/\s*$/g, " ")
+        .replace(/^\s*\*/gm, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+      for (const match of prose.matchAll(promise)) {
+        const rest = prose.slice(match.index)
+        const stop = Math.min(
+          ...[/[.;!?]\s/.exec(rest)?.index, /\s@\w/.exec(rest)?.index, 200]
+            .filter(index => index !== undefined)
+            .map(Number),
+        )
+        const sentence = rest.slice(0, stop)
+        for (const [identifier] of sentence.matchAll(/[A-Za-z_$][\w$]*/g)) {
+          if (exported.has(identifier)) {
+            found.push({
+              symbol: identifier,
+              file: relative(ROOT, file),
+              sentence,
+            })
+          }
+        }
+      }
+    }
+  }
+  return found
+}
+
 describe("public exports", () => {
-  it("exports the client", () => {
-    expect(seaportJs).to.have.property("Seaport")
+  it("finds the docs it is supposed to read", () => {
+    // Vacuity guard. Every check below reports "nothing missing" when its
+    // regex stops matching, so pin that the inputs are non-empty.
+    expect(
+      SOURCE_FILES.length,
+      "TypeScript files under src/",
+    ).to.be.greaterThan(0)
+    expect(
+      readmeImportedSymbols().length,
+      `named imports of ${PACKAGE_NAME} in README code fences`,
+    ).to.be.greaterThan(0)
+    expect(
+      exportedDeclarations().size,
+      "exported declarations under src/",
+    ).to.be.greaterThan(0)
   })
 
-  it("exports ItemType, which the README's order examples are written with", () => {
-    expect(seaportJs).to.have.property("ItemType")
+  it("exports every symbol the README's code examples import", () => {
+    const missing = readmeImportedSymbols()
+      .filter(({ symbol }) => !publicExports.has(symbol))
+      .map(({ symbol, statement }) => `${symbol} (README: ${statement})`)
+
+    expect(
+      missing,
+      "README code examples import symbols that src/index.ts does not export, " +
+        "so copying the example fails at import",
+    ).to.deep.equal([])
+  })
+
+  it("exports every helper a doc comment promises is exposed", () => {
+    const missing = docCommentPromises()
+      .filter(({ symbol }) => !publicExports.has(symbol))
+      .map(({ symbol, file, sentence }) => `${symbol} (${file}: "${sentence}")`)
+
+    expect(
+      missing,
+      "a doc comment points readers at a helper that src/index.ts does not " +
+        "export, so the reader cannot import it",
+    ).to.deep.equal([])
+  })
+
+  it("keeps ItemType's numeric values, which the examples depend on", () => {
+    // Not derivable from the docs: the README writes `ItemType.ERC721`, and
+    // the number behind it is the Seaport wire value.
+    expect(seaportJs.ItemType.NATIVE).to.eq(0)
+    expect(seaportJs.ItemType.ERC20).to.eq(1)
     expect(seaportJs.ItemType.ERC721).to.eq(2)
-  })
-
-  it("exports getMaximumSizeForOrder, which fulfillOrder's docs point at", () => {
-    expect(seaportJs).to.have.property("getMaximumSizeForOrder")
-    expect(seaportJs.getMaximumSizeForOrder).to.be.a("function")
+    expect(seaportJs.ItemType.ERC1155).to.eq(3)
   })
 })


### PR DESCRIPTION
## Motivation

seaport-js#983 was reported by a member of the public. Both README order examples were written with `ItemType`, and `fulfillOrder`'s doc comment told readers "We expose a helper to get this: getMaximumSizeForOrder". `src/index.ts` exported only `Seaport`, so neither name was importable and anyone who copied an example got a runtime failure.

That was fixed, and `test/public-exports.spec.ts` was added alongside it. The test restates the three names by hand:

```ts
expect(seaportJs).to.have.property("ItemType")
expect(seaportJs).to.have.property("getMaximumSizeForOrder")
```

A hand-written list only covers the names someone thought to add. The next README example that reaches for a fourth symbol, or the next doc comment that promises a helper, reintroduces exactly the same gap with the suite still green.

## Solution

Read the docs rather than restating them. The suite now derives what it checks:

1. Every named value import of the package written in a fenced code block in README.md must be reachable from `src/index.ts`. The package name comes from `package.json`, so a rename cannot silently disable the scan.
2. Every identifier named in an "expose" sentence inside a JSDoc block under `src/` must be reachable from `src/index.ts`, where "identifier" is narrowed to names that are also top-level exported declarations somewhere in `src/`. That filter is what keeps ordinary English out of the result: the other "expose" sentence in the codebase, in `utils/order.ts`, mentions `createOrder`, `getMessageToSign` and `orderComponents`, none of which are exported declarations, so it contributes nothing.

A fourth test keeps `ItemType`'s numeric values pinned. Those are Seaport wire values, and no doc scan can express them.

The three hand-written assertions are subsumed: `Seaport` and `ItemType` are both README imports, `getMaximumSizeForOrder` is the doc-comment promise.

### What this does not cover

Worth being plain about, because the check reports "nothing missing" for all of these:

- Type-only imports. `import type { … }` and a `type X` specifier are dropped, because they do not exist on a module namespace at runtime. `npm run lint` runs `tsc`, which does resolve them.
- Deep imports such as `@opensea/seaport-js/lib/utils/item`, which bypass the entry point by design.
- Member access. A README writing `ItemType.NOT_A_REAL_MEMBER` still passes; only the import statement is read.
- Prose outside a fenced code block, and any doc-comment promise phrased without the word "expose".
- Docs outside README.md and `src/`.

The first test in the file is a vacuity guard for the rest: it asserts the source-file walk, the README import scan and the exported-declaration scan each found something, so a regex that stops matching fails loudly instead of passing empty.

## Tripwire evidence

Each check was verified by reverting the thing it is supposed to protect and confirming it fails on its own assertion, not on a module-load error.

Removing `ItemType` from `src/index.ts`:

```
1) public exports
     exports every symbol the README's code examples import:

    README code examples import symbols that src/index.ts does not export, so copying the example fails at import
    + expected - actual

    -[
    -  "ItemType (README: import { ItemType } from \"@opensea/seaport-js\")"
    -  "ItemType (README: import { ItemType } from \"@opensea/seaport-js\")"
    -]
    +[]
```

Removing `getMaximumSizeForOrder` from `src/index.ts`:

```
1) public exports
     exports every helper a doc comment promises is exposed:

    a doc comment points readers at a helper that src/index.ts does not export, so the reader cannot import it
    + expected - actual

    -[
    -  "getMaximumSizeForOrder (src/seaport.ts: \"expose a helper to get this: getMaximumSizeForOrder i.e\")"
    -]
    +[]
```

Those two are the reported bug. To show the check is mechanical rather than a rephrased list, it was also run against content that has never existed in this repo. Appending a fence to README.md that imports `getBulkOrderTree`, a real `src/utils/eip712/bulk-orders.ts` export that the entry point does not re-export:

```
    -[
    -  "getBulkOrderTree (README: import { getBulkOrderTree } from \"@opensea/seaport-js\")"
    -]
    +[]
```

And adding a new doc-comment line "We expose a helper that does the item mapping: mapInputItemToOfferItem" to `src/utils/order.ts`:

```
    -[
    -  "mapInputItemToOfferItem (src/utils/order.ts: \"expose a helper that does the item mapping: mapInputItemToOfferItem ...\")"
    -]
    +[]
```

All four temporary edits were reverted; the diff is one test file.

## Verification

Run separately, with real exit codes, on the branch as pushed.

| Command | Exit |
| --- | --- |
| `npm run lint` (`tsc --noEmit` plus `biome check .`) | 0 |
| `npm test` (`hardhat test`) | 0, 243 passing |

`npm ci` and `npx hardhat compile` were run first so `src/typechain-types` exists. Note that `hardhat test` runs mocha without typechecking, which is why `npm run lint` was run as its own command rather than inferred from a green test run.
