### PR TITLE
docs: point security reports at Bugcrowd in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@ Thank you for your Pull Request. Please provide a description above and review
 the requirements below.
 
 Bug fixes and new features should include tests.
+
+Do not report security vulnerabilities in a public pull request or issue. Use
+https://bugcrowd.com/engagements/opensea instead.
 -->
 
 ## Motivation


### PR DESCRIPTION
## Motivation

The template already keeps its guidance inside HTML comments, so none of it leaks into contributor PR bodies. What it does not say is where to send a security report, and a vulnerability filed as a public pull request or issue is disclosed the moment it is opened.

## Solution

One line added to the leading comment block, pointing at https://bugcrowd.com/engagements/opensea. Nothing else changes, and the rendered template is still just the Motivation and Solution headings.

Part of a sweep across the public OpenSea repos. The mirrored packages in opensea-devtools had the opposite problem: their template was plain markdown rather than a comment, so every community PR body opened with our own boilerplate. See opensea-sdk pull requests 1997 through 2000, all opened the same day, each beginning with "Thanks for opening a PR" before the author gets a word in.

Verified by stripping the HTML comments from the file and confirming the remainder is two headings and blank lines.