### PR TITLE
fix: scale remaining order amounts exactly, not through basis points

### DIFF
--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -236,27 +236,36 @@ export const mapOrderAmountsFromFilledStatus = (
   }
 
   // i.e if totalFilled is 3 and totalSize is 4, there are 1 / 4 order amounts left to fill.
-  const basisPoints =
-    ((totalSize - totalFilled) * ONE_HUNDRED_PERCENT_BP) / totalSize
+  const remainingUnits = totalSize - totalFilled
 
   return {
     parameters: {
       ...order.parameters,
       offer: order.parameters.offer.map(item => ({
         ...item,
-        startAmount: multiplyBasisPoints(
+        startAmount: multiplyDivision(
           item.startAmount,
-          basisPoints,
+          remainingUnits,
+          totalSize,
         ).toString(),
-        endAmount: multiplyBasisPoints(item.endAmount, basisPoints).toString(),
+        endAmount: multiplyDivision(
+          item.endAmount,
+          remainingUnits,
+          totalSize,
+        ).toString(),
       })),
       consideration: order.parameters.consideration.map(item => ({
         ...item,
-        startAmount: multiplyBasisPoints(
+        startAmount: multiplyDivision(
           item.startAmount,
-          basisPoints,
+          remainingUnits,
+          totalSize,
         ).toString(),
-        endAmount: multiplyBasisPoints(item.endAmount, basisPoints).toString(),
+        endAmount: multiplyDivision(
+          item.endAmount,
+          remainingUnits,
+          totalSize,
+        ).toString(),
       })),
     },
     signature: order.signature,
@@ -361,13 +370,20 @@ export function mapTipAmountsFromFilledStatus(
   }
 
   // i.e if totalFilled is 3 and totalSize is 4, there are 1 / 4 order amounts left to fill.
-  const basisPoints =
-    ((totalSize - totalFilled) * ONE_HUNDRED_PERCENT_BP) / totalSize
+  const remainingUnits = totalSize - totalFilled
 
   return tips.map(tip => ({
     ...tip,
-    startAmount: multiplyBasisPoints(tip.startAmount, basisPoints).toString(),
-    endAmount: multiplyBasisPoints(tip.endAmount, basisPoints).toString(),
+    startAmount: multiplyDivision(
+      tip.startAmount,
+      remainingUnits,
+      totalSize,
+    ).toString(),
+    endAmount: multiplyDivision(
+      tip.endAmount,
+      remainingUnits,
+      totalSize,
+    ).toString(),
   }))
 }
 

--- a/test/fulfill-remaining-default-amount.spec.ts
+++ b/test/fulfill-remaining-default-amount.spec.ts
@@ -1,0 +1,163 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types"
+import { expect } from "chai"
+import { parseEther } from "ethers"
+import { ItemType } from "../src/constants"
+import type { CreateOrderInput } from "../src/types"
+import { describeWithFixture } from "./utils/setup"
+
+// mapOrderAmountsFromFilledStatus is what runs on the default "fill whatever
+// is left" path (no unitsToFill passed in). Its sibling mapOrderAmountsFromUnitsToFill
+// scales amounts with a single exact division; this one used to go through a
+// basis points detour instead, which loses precision whenever totalSize does
+// not divide evenly into basis points. 9 ETH over 3 units, with 1 unit
+// already taken, leaves a remaining fraction of 2/3, which basis points
+// cannot represent exactly (6666 bp, not 6666.67), so the old code sent
+// 5.9994 ETH instead of the 6 ETH the contract actually requires and reverted
+// with InsufficientNativeTokensSupplied.
+describeWithFixture(
+  "As a user I want the default fill-remaining path to send the exact amount owed",
+  fixture => {
+    let offerer: HardhatEthersSigner
+    let firstFulfiller: HardhatEthersSigner
+    let secondFulfiller: HardhatEthersSigner
+
+    const totalUnits = 3
+    // 9, not 10: gcd(3, 9 ETH in wei) is 3, so the order is genuinely
+    // divisible into thirds instead of collapsing to a single fillable unit.
+    const price = parseEther("9")
+
+    const listing = async (nftId: string): Promise<CreateOrderInput> => ({
+      startTime: "0",
+      allowPartialFills: true,
+      offer: [
+        {
+          itemType: ItemType.ERC1155,
+          token: await fixture.testErc1155.getAddress(),
+          identifier: nftId,
+          amount: String(totalUnits),
+        },
+      ],
+      consideration: [
+        { amount: price.toString(), recipient: await offerer.getAddress() },
+      ],
+    })
+
+    beforeEach(async () => {
+      const { ethers } = fixture
+      ;[offerer, , firstFulfiller, secondFulfiller] = await ethers.getSigners()
+    })
+
+    it("builds a transaction whose value is the exact remaining native amount, not a basis points approximation", async () => {
+      const { seaport, testErc1155 } = fixture
+      const nftId = "1"
+
+      await testErc1155.mint(await offerer.getAddress(), nftId, totalUnits)
+      const order = await (
+        await seaport.createOrder(await listing(nftId))
+      ).executeAllActions()
+
+      // First fulfiller explicitly takes 1 of 3 units, leaving 2/3 remaining.
+      const first = await seaport.fulfillOrder({
+        order,
+        unitsToFill: 1,
+        accountAddress: await firstFulfiller.getAddress(),
+      })
+      for (const action of first.actions) {
+        await (await action.transactionMethods.transact()).wait()
+      }
+
+      const orderHash = seaport.getOrderHash(order.parameters)
+      const status = await seaport.getOrderStatus(orderHash)
+
+      // Exact remaining fraction: 2/3 of 9 ETH = 6 ETH.
+      const exactRemaining =
+        (price * (status.totalSize - status.totalFilled)) / status.totalSize
+      expect(exactRemaining).to.eq(parseEther("6"))
+
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        accountAddress: await secondFulfiller.getAddress(),
+      })
+      const fulfillAction = actions[actions.length - 1]
+      const transaction =
+        await fulfillAction.transactionMethods.buildTransaction()
+
+      expect(transaction.value).to.eq(exactRemaining)
+
+      await (await fulfillAction.transactionMethods.transact()).wait()
+
+      expect(
+        await testErc1155.balanceOf(await secondFulfiller.getAddress(), nftId),
+      ).to.eq(2n)
+    })
+
+    // The actual ERC20 transfer amount is decided on chain by Seaport's own
+    // numerator/denominator math, not by the SDK's local estimate, so it is
+    // correct either way and cannot show this bug. exactApproval routes the
+    // SDK's estimate into a real approve() call instead, which is where an
+    // under counted amount is actually observable: the approval this issues
+    // would come up short of what the contract goes on to pull.
+    it("with exactApproval approves the exact remaining amount, not a basis points approximation", async () => {
+      const { seaport, testErc1155, testErc20 } = fixture
+      const nftId = "2"
+      const operator = await seaport.contract.getAddress()
+
+      await testErc1155.mint(await offerer.getAddress(), nftId, totalUnits)
+      await testErc20.mint(await firstFulfiller.getAddress(), price)
+      await testErc20.mint(await secondFulfiller.getAddress(), price)
+
+      const input: CreateOrderInput = {
+        startTime: "0",
+        allowPartialFills: true,
+        offer: [
+          {
+            itemType: ItemType.ERC1155,
+            token: await testErc1155.getAddress(),
+            identifier: nftId,
+            amount: String(totalUnits),
+          },
+        ],
+        consideration: [
+          {
+            amount: price.toString(),
+            token: await testErc20.getAddress(),
+            recipient: await offerer.getAddress(),
+          },
+        ],
+      }
+
+      const order = await (await seaport.createOrder(input)).executeAllActions()
+
+      const first = await seaport.fulfillOrder({
+        order,
+        unitsToFill: 1,
+        accountAddress: await firstFulfiller.getAddress(),
+      })
+      for (const action of first.actions) {
+        await (await action.transactionMethods.transact()).wait()
+      }
+
+      const orderHash = seaport.getOrderHash(order.parameters)
+      const status = await seaport.getOrderStatus(orderHash)
+      const exactRemaining =
+        (price * (status.totalSize - status.totalFilled)) / status.totalSize
+      expect(exactRemaining).to.eq(parseEther("6"))
+
+      const { actions } = await seaport.fulfillOrder({
+        order,
+        accountAddress: await secondFulfiller.getAddress(),
+        exactApproval: true,
+      })
+
+      const approvalAction = actions.find(action => action.type === "approval")
+      expect(approvalAction, "expected an approval action").to.not.be.undefined
+      await (await approvalAction!.transactionMethods.transact()).wait()
+
+      const approvedAmount = await testErc20.allowance(
+        await secondFulfiller.getAddress(),
+        operator,
+      )
+      expect(approvedAmount).to.eq(exactRemaining)
+    })
+  },
+)


### PR DESCRIPTION
## Problem

`mapOrderAmountsFromFilledStatus` and `mapTipAmountsFromFilledStatus` (src/utils/order.ts) compute the remaining-fill fraction by rounding it to basis points first, then multiplying:

    const basisPoints = ((totalSize - totalFilled) * ONE_HUNDRED_PERCENT_BP) / totalSize
    ...
    startAmount: multiplyBasisPoints(item.startAmount, basisPoints).toString(),

This is a double-rounded approximation. Basis points only have 1/10000 granularity, so whenever totalSize does not divide evenly into 10000 the result is wrong, not just imprecise.

Concretely: a 9 ETH ERC1155 order split into 3 units, with 1 unit already filled by another fulfiller, leaves a remaining fraction of 2/3. 2/3 as basis points floors to 6666 (not 6666.67), and multiplying back gives 5.9994 ETH instead of the true 6 ETH. This function runs on the default fulfillOrder path, i.e. every call that does not pass an explicit unitsToFill, so it feeds directly into the built transaction's value for native-priced orders. The result is a transaction that reverts with InsufficientNativeTokensSupplied for an ordinary partial fill, on a pre-flight-checked call that should have succeeded.

I confirmed against seaport-core that the fill fraction itself is exact or revert on chain: AmountDeriver._getFraction reverts with InexactFraction() on any remainder, so there is no legitimate case where the true remaining amount is anything other than an exact integer. The bug is not that the SDK rounds in the wrong direction, it is that it computes the wrong exact integer via an unnecessary lossy detour.

## Fix

Replace the basis-points detour with the same single exact division the sibling functions already use. `multiplyDivision` already exists in this file, added by #197:

    const multiplyDivision = (amount, numerator, denominator) =>
      (BigInt(amount) * BigInt(numerator)) / BigInt(denominator)

That fix (#197, closing #141 and #185, the exact same InsufficientEtherSupplied-on-partial-fill symptom this bug produces) applied `multiplyDivision` to `mapOrderAmountsFromUnitsToFill` and `mapTipAmountsFromUnitsToFill`. It never reached `mapOrderAmountsFromFilledStatus` or `mapTipAmountsFromFilledStatus`, their neighbors in the same file, which is why the same bug class is still here on the default fill path. This PR finishes applying that fix to the two functions it missed. `multiplyBasisPoints` is unchanged and still used correctly by `feeToConsiderationItem` and `deductFees`.

## Validation

- npm run build
- npm run lint
- npm run format:check
- npm run test (245 passing, up from 243)
- npm run coverage

New regression test in test/fulfill-remaining-default-amount.spec.ts: a 9 ETH / 3 unit ERC1155 order, 1 unit taken by a first fulfiller, fulfilled for the remainder by a second fulfiller via the default path (no unitsToFill). Asserts the built transaction's value equals the exact remaining amount (6 ETH), and, for the ERC20-priced equivalent with exactApproval, that the resulting approve() sets the exact allowance rather than the basis-points approximation. Both assertions fail against unmodified main with the exact 5999400000000000000 vs 6000000000000000000 mismatch described above, confirming they catch the bug.