### PR TITLE
chore: bump version to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/seaport-js",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "[Seaport](https://github.com/ProjectOpenSea/seaport) is a marketplace protocol for safely and efficiently buying and selling NFTs. This is a TypeScript library intended to make interfacing with the contract reasonable and easy.",
   "license": "MIT",
   "author": "OpenSea Developers",


### PR DESCRIPTION
Bumps the version only. 16 commits have landed since `v4.2.0`.

## Why minor and not patch

Checked against the diff rather than the commit messages.

`src/index.ts` gained two exports, `ItemType` and `getMaximumSizeForOrder`, which is additive. `OrderUseCase`'s exchange branch changed from `ContractTransaction` to `TransactionResponse`, which narrows a public type; the old annotation was wrong, since `transact()` always returned a response, but it is still a change anyone with an explicit annotation will see.

Several changes also throw where the previous code returned or proceeded: a batch where nothing is fulfillable, a fulfiller who cannot cover a forwarded-offer batch, and a fulfiller who cannot cover a whole batch. A new throw on input that previously returned is a behavior change, so patch is wrong here. Nothing was removed, so this is not a major.

## What is in it

Eight community contributions landed as #985, with #986 closing a gap between #984 and #978 that only existed once both were on main. Then #988 replaced the hardcoded public-export test with one derived from the docs, and #973, #974, #975 and #984 landed before that.

The behavior worth calling out for anyone upgrading:

- `fulfillOrders` now drops orders it cannot fill and settles the rest, matching what `fulfillAvailableAdvancedOrders` does on chain, instead of throwing on the first cancelled or filled one. It still throws when nothing in the batch can be filled.
- `unitsToFill` is capped at what remains of a partially filled order, as Seaport itself caps it.
- The balance check no longer credits the fulfiller with offer items that `recipientAddress` forwards elsewhere, on the single-order path and the batch path.
- A fee that rounds down to zero at both ends is left out of the consideration instead of producing an order Seaport rejects with `MissingItemAmount`.
- A conduit key resolves whatever hex case it arrives in.

## Security pass

Every change in this range moves risk in the same direction: stricter balance checks, refusing to guess rather than guessing, and dropping items that made an order unfillable. Nothing widens an approval's scope or loosens a currency, recipient or amount check. `npm audit --omit=dev` reports 0 vulnerabilities.

## Verification

`npm ci`, `npx hardhat compile`, `npm run lint` and `npm test` all clean, 243 passing. Lint is tsc plus Biome and was run separately from the test run, since hardhat runs mocha without typechecking.
