### PR TITLE
chore: normalise line endings to LF on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalise line endings to LF in the working tree.
+#
+# Git hands Windows checkouts CRLF by default, which diverges from what
+# everything else here already assumes: biome.json sets "lineEnding": "lf",
+# and CI checks out LF. That gap caused a real failure. The README scan in
+# test/public-exports.spec.ts anchored its code-fence regex on \n, so on a
+# CRLF clone it matched nothing and two export checks passed over an empty
+# document while looking green.
+#
+# PR #990 fixed that parse to read either ending. This stops the divergence
+# at the source, for every file rather than the one that happened to break.
+* text=auto eol=lf
+
+# The only binary file tracked today. text=auto already detects it, but being
+# explicit keeps that true if more images are added.
+*.png binary


### PR DESCRIPTION
Follow-up to [#990](https://github.com/ProjectOpenSea/seaport-js/pull/990), which I flagged there as worth doing separately.

## Why

`biome.json` already sets `"lineEnding": "lf"` and CI checks out LF, but nothing made git itself agree. A contributor on Windows gets CRLF working files that the rest of the tooling does not expect.

That gap is not hypothetical. It is what #990 ran into: the README scan in `test/public-exports.spec.ts` anchored its code-fence regex on `\n`, so on a CRLF clone it matched nothing, and `exports every symbol the README's code examples import` and `exports every helper a doc comment promises is exposed` both passed over an empty document while looking green. Only the vacuity guard noticed.

#990 fixed the parse to read either ending, which is the right fix for that file and holds however the clone happened. This fixes the divergence at the source, so the next scan someone writes does not have to remember.

## Scope

```
* text=auto eol=lf
*.png binary
```

`img/banner.png` is the only binary file tracked today. `text=auto` already detects it correctly; the explicit line keeps that true if more images land.

## No churn

The repo is already uniformly LF in the index, which is why CI has always been green. `git add --renormalize .` after adding the file reports nothing to change, so this rewrites no content and produces no diff on anyone's next checkout of existing files.

Verified with `git check-attr`: text files resolve to `text: auto, eol: lf`, and `img/banner.png` resolves to `text: unset, binary: set`.

## Checks

`npm run lint` passes and `npm test` is 246 passing, unchanged from main.

I cannot approve my own PR, so this needs a code-owner review before it can merge.
